### PR TITLE
fix: llm pre process logic

### DIFF
--- a/src/utils/classify-pre.ts
+++ b/src/utils/classify-pre.ts
@@ -1,6 +1,6 @@
 import { CONVENTIONAL_PREFIX_RE, REFACTOR_LIKE_RE } from '@/constants/conventional.js';
 import type { ReleaseItem } from '@/types/release.js';
-import { isImplicitFixTitle } from '@/utils/category-tune.js';
+import { isImplicitFixTitle, isChangeLikeTitle } from '@/utils/category-tune.js';
 
 
 /**
@@ -33,6 +33,12 @@ export function buildTitlesForClassification(items: ReleaseItem[]): string[] {
 
     // Normalize refactor/perf/style to refactor: for consistent Changed mapping.
     if (REFACTOR_LIKE_RE.test(lower)) {
+      out.push(REFACTOR_PREFIX_RE.test(lower) ? base : `refactor: ${core}`);
+      continue;
+    }
+
+    // Nudge change-like improvements toward Changed by presenting as refactor.
+    if (isChangeLikeTitle(base)) {
       out.push(REFACTOR_PREFIX_RE.test(lower) ? base : `refactor: ${core}`);
       continue;
     }


### PR DESCRIPTION
## Summary

Improve category tuning to classify “improvement/tuning/optimization” style titles under Changed, and nudge LLM inputs accordingly without relying on domain-specific keywords.

<!-- A brief summary of the changes -->

## Description

- Generalized improvement indicators (e.g., improve, enhance, optimize, refine, streamline, simplify, rework, revise, stabilize, harden, tweak, adjust, fine‑tune/tuning).
- Removed `domain-specific` terms (`preprocess/postprocess`) to reduce false positives.
- `classify-pre` now uses the new indicator to present change-like titles as refactor: to bias the LLM toward Changed.
- Preserved implicit fix detection: “typing/contract corrections” still move to Fixed and override other signals

<!-- A detailed explanation of the changes, including why they are needed -->
