### PR TITLE
fix: category tune fix types

### DIFF
--- a/src/utils/category-tune.ts
+++ b/src/utils/category-tune.ts
@@ -175,7 +175,7 @@ export function tuneCategoriesByTitle(
   if (toMove.length) moveTitlesToCategory(adjusted, toMove, 'Fixed');
 
   // Rule: Conventional `fix:` prefix should map to Fixed (guard against LLM misclassifying as Chore).
-  const FIX_PREFIX_RE = /^fix(\(|:)/i;
+  const FIX_PREFIX_RE = /^fix!?(\(|:)/i;
   const conventionalFixes: string[] = [];
   for (const title of knownTitles) {
     if (FIX_PREFIX_RE.test(title)) conventionalFixes.push(title);


### PR DESCRIPTION
## Summary

Fix category tune fix types.

<!-- A brief summary of the changes -->

## Description

- Remove early return because it skips categorizing.
- Add `fix:` prefix categorization.

<!-- A detailed explanation of the changes, including why they are needed -->
