### PR TITLE
fix(github-app): add App auth via installation tokens + CI-safe env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,9 @@ export OPENAI_API_KEY=sk-...
 # --- GitHub App authentication (optional; prefer this in CI) ---
 # Use these instead of GITHUB_TOKEN to brand as your App.
 # Required: App ID and Private Key. Installation ID optional (auto-detected for the repo).
-# export GITHUB_APP_ID=123456
-# export GITHUB_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
-# export GITHUB_APP_INSTALLATION_ID=987654
+# export CHANGELOG_BOT_APP_ID=123456
+# export CHANGELOG_BOT_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+# export CHANGELOG_BOT_APP_INSTALLATION_ID=987654
 
 # For GHES only, override the REST base URL (default: https://api.github.com)
-# export GITHUB_API_BASE=https://ghe.example.com/api/v3
+# export CHANGELOG_BOT_API_BASE=https://ghe.example.com/api/v3

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ Bring your own keys and tokens as needed—`changelog-bot` only asks for what it
 - Environment variables:
   - `GITHUB_TOKEN` (required for PR creation; not required for `--dry-run`)
   - Or GitHub App auth (recommended for branding and least-privilege):
-    - `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` (required)
-    - `GITHUB_APP_INSTALLATION_ID` (optional; auto-detected per repo)
-    - `GITHUB_API_BASE` (optional; GHES, e.g., `https://ghe.example.com/api/v3`)
+    - `CHANGELOG_BOT_APP_ID` and `CHANGELOG_BOT_APP_PRIVATE_KEY` (required)
+    - `CHANGELOG_BOT_APP_INSTALLATION_ID` (optional; auto-detected per repo)
+    - `CHANGELOG_BOT_API_BASE` (optional; GHES, e.g., `https://ghe.example.com/api/v3`)
   - `OPENAI_API_KEY` (optional)
   - `ANTHROPIC_API_KEY` (optional)
   - `REPO_FULL_NAME` (optional, `owner/repo`; used for link resolution)
@@ -271,12 +271,12 @@ jobs:
           release-name: ${{ github.event.release.tag_name }}
         env:
           # Use App auth (do not set GITHUB_TOKEN to force App path)
-          GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
+          CHANGELOG_BOT_APP_ID: ${{ secrets.CHANGELOG_BOT_APP_ID }}
+          CHANGELOG_BOT_APP_PRIVATE_KEY: ${{ secrets.CHANGELOG_BOT_APP_PRIVATE_KEY }}
           # Optional: hardcode installation id; otherwise auto-detected
-          # GITHUB_APP_INSTALLATION_ID: ${{ secrets.GITHUB_APP_INSTALLATION_ID }}
+          # CHANGELOG_BOT_APP_INSTALLATION_ID: ${{ secrets.CHANGELOG_BOT_APP_INSTALLATION_ID }}
           # Optional: GHES
-          # GITHUB_API_BASE: https://ghe.example.com/api/v3
+          # CHANGELOG_BOT_API_BASE: https://ghe.example.com/api/v3
           # Optional: AI keys
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -312,10 +312,10 @@ jobs:
             --provider openai
         env:
           REPO_FULL_NAME: ${{ github.repository }}
-          GITHUB_APP_ID: ${{ secrets.GITHUB_APP_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
-          # GITHUB_APP_INSTALLATION_ID: ${{ secrets.GITHUB_APP_INSTALLATION_ID }}
-          # GITHUB_API_BASE: https://ghe.example.com/api/v3
+          CHANGELOG_BOT_APP_ID: ${{ secrets.CHANGELOG_BOT_APP_ID }}
+          CHANGELOG_BOT_APP_PRIVATE_KEY: ${{ secrets.CHANGELOG_BOT_APP_PRIVATE_KEY }}
+          # CHANGELOG_BOT_APP_INSTALLATION_ID: ${{ secrets.CHANGELOG_BOT_APP_INSTALLATION_ID }}
+          # CHANGELOG_BOT_API_BASE: https://ghe.example.com/api/v3
           # OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
@@ -328,13 +328,13 @@ Notes
 
 If you install `changelog-bot` as a GitHub App in your org, the PRs will be authored by the App’s account and you can scope permissions cleanly.
 
-Set the following in your workflow or environment:
+Set the following in your workflow or environment (use aliases; no `GITHUB_` prefix required):
 
 ```sh
-export GITHUB_APP_ID=123456
-export GITHUB_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+export CHANGELOG_BOT_APP_ID=123456
+export CHANGELOG_BOT_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 # Optional: hardcode installation id; otherwise we auto-detect from the repo
-# export GITHUB_APP_INSTALLATION_ID=987654
+# export CHANGELOG_BOT_APP_INSTALLATION_ID=987654
 ```
 
 The CLI exchanges the App credentials for an installation access token at runtime and uses it for:

--- a/src/constants/github.ts
+++ b/src/constants/github.ts
@@ -5,7 +5,9 @@ export const PRS_LOOKUP_COMMIT_LIMIT = 200;
 // API base; override for GHES via env
 export const GITHUB_API_BASE_DEFAULT = 'https://api.github.com';
 export const GITHUB_API_BASE =
-  process.env.GITHUB_API_BASE || GITHUB_API_BASE_DEFAULT;
+  process.env.CHANGELOG_BOT_API_BASE ||
+  process.env.GITHUB_API_BASE ||
+  GITHUB_API_BASE_DEFAULT;
 
 // GitHub App JWT parameters
 export const GITHUB_APP_JWT_SKEW_SECONDS = 60; // allow small clock drift

--- a/src/schema/env.ts
+++ b/src/schema/env.ts
@@ -7,14 +7,11 @@ import { z } from 'zod';
 export const EnvSchema = z.object({
   GITHUB_TOKEN: z.string().min(1).optional(),
   // GitHub App credentials (optional; used when PAT is absent)
-  GITHUB_APP_ID: z.string().min(1).optional(),
-  /**
-   * GitHub App private key in PEM format. Supports either literal multiline
-   * PEM or a single-line value with \n sequences.
-   */
-  GITHUB_APP_PRIVATE_KEY: z.string().min(1).optional(),
-  /** Optional installation id; autodetected from repo when omitted. */
-  GITHUB_APP_INSTALLATION_ID: z.string().min(1).optional(),
+  // NOTE: Use aliases that do not start with GITHUB_ to avoid Secrets restrictions.
+  CHANGELOG_BOT_APP_ID: z.string().min(1).optional(),
+  CHANGELOG_BOT_APP_PRIVATE_KEY: z.string().min(1).optional(),
+  CHANGELOG_BOT_APP_INSTALLATION_ID: z.string().min(1).optional(),
+  CHANGELOG_BOT_API_BASE: z.string().min(1).optional(),
   OPENAI_API_KEY: z.string().min(1).optional(),
   ANTHROPIC_API_KEY: z.string().min(1).optional(),
   REPO_FULL_NAME: z.string().min(1).optional(),

--- a/src/utils/github-auth.ts
+++ b/src/utils/github-auth.ts
@@ -99,15 +99,16 @@ export async function resolveGitHubAuth(
   const pat = get('GITHUB_TOKEN');
   if (pat) return { token: pat, source: 'pat' };
 
-  const appId = get('GITHUB_APP_ID');
-  const privateKeyRaw = get('GITHUB_APP_PRIVATE_KEY');
+  // Use CI-safe aliases only (no GITHUB_ prefix for Secrets compatibility)
+  const appId = get('CHANGELOG_BOT_APP_ID');
+  const privateKeyRaw = get('CHANGELOG_BOT_APP_PRIVATE_KEY');
   if (!appId || !privateKeyRaw) return undefined;
 
   const privateKey = normalizePrivateKey(String(privateKeyRaw));
   const jwt = createAppJwt(String(appId), privateKey);
 
   // Determine installation id: env or via repo lookup
-  let installationId = get('GITHUB_APP_INSTALLATION_ID');
+  let installationId = get('CHANGELOG_BOT_APP_INSTALLATION_ID');
   if (!installationId) {
     const instUrl = `${GITHUB_API_BASE}/repos/${owner}/${repo}/installation`;
     const inst = await getJson<unknown>(instUrl, ghHeaders(jwt), 'GitHub API');

--- a/tests/utils/github-auth.test.ts
+++ b/tests/utils/github-auth.test.ts
@@ -29,9 +29,9 @@ describe('github-auth utils', () => {
     process.env = { ...originalEnv };
     // default: undefined token/app vars
     delete process.env.GITHUB_TOKEN;
-    delete process.env.GITHUB_APP_ID;
-    delete process.env.GITHUB_APP_PRIVATE_KEY;
-    delete process.env.GITHUB_APP_INSTALLATION_ID;
+    delete process.env.CHANGELOG_BOT_APP_ID;
+    delete process.env.CHANGELOG_BOT_APP_PRIVATE_KEY;
+    delete process.env.CHANGELOG_BOT_APP_INSTALLATION_ID;
     delete process.env.GITHUB_API_BASE;
   });
 
@@ -49,9 +49,9 @@ describe('github-auth utils', () => {
   });
 
   test('exchanges App credentials for installation token (auto-detect install)', async () => {
-    process.env.GITHUB_APP_ID = '12345';
+    process.env.CHANGELOG_BOT_APP_ID = '12345';
     // Provide a private key with \n escapes; normalization should handle it
-    process.env.GITHUB_APP_PRIVATE_KEY =
+    process.env.CHANGELOG_BOT_APP_PRIVATE_KEY =
       '-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n';
 
     const calls: Array<{ url: string; options: any }> = [];
@@ -91,10 +91,10 @@ describe('github-auth utils', () => {
   });
 
   test('uses provided installation id and skips detection', async () => {
-    process.env.GITHUB_APP_ID = '12345';
-    process.env.GITHUB_APP_PRIVATE_KEY =
+    process.env.CHANGELOG_BOT_APP_ID = '12345';
+    process.env.CHANGELOG_BOT_APP_PRIVATE_KEY =
       '-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----\\n';
-    process.env.GITHUB_APP_INSTALLATION_ID = '777';
+    process.env.CHANGELOG_BOT_APP_INSTALLATION_ID = '777';
 
     let requestCount = 0;
     global.fetch = jest.fn().mockImplementation(async (url: string) => {


### PR DESCRIPTION
## Summary

Add GitHub App authentication (installation tokens) with PAT fallback. Introduce CI-safe env aliases (`CHANGELOG_BOT_**`), `GHES` base URL support, and unit tests. Docs updated with clear Actions YAML.

<!-- A brief summary of the changes -->

## Description

- New token resolver that prefers `GITHUB_TOKEN` (PAT/Actions) and falls back to GitHub App installation tokens.
- Reads CI-safe aliases: `CHANGELOG_BOT_APP_ID`, `CHANGELOG_BOT_APP_PRIVATE_KEY`, optional `CHANGELOG_BOT_APP_INSTALLATION_ID`.
- GHES: `CHANGELOG_BOT_API_BASE` (fallback: `GITHUB_API_BASE`) to override REST base URL.

<!-- A detailed explanation of the changes, including why they are needed -->
