### PR TITLE
fix: classification to use json base response

### DIFF
--- a/src/utils/classify.ts
+++ b/src/utils/classify.ts
@@ -96,7 +96,7 @@ function buildAnthropicRequest(
 ): RequestConfig {
   // Define a structured output schema via tools to force JSON.
   const properties: Record<string, unknown> = {};
-  for (const cat of SECTION_ORDER) {
+  for (const cat of prompt.categories) {
     properties[cat] = { type: 'array', items: { type: 'string' } };
   }
   const payload = {


### PR DESCRIPTION
## Summary

Fix classification to use `json-base` response.

<!-- A brief summary of the changes -->

## Description

Explicit using json base response and fix classification logic.

<!-- A detailed explanation of the changes, including why they are needed -->
