### PR TITLE
fix: help message should be in English

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ import { buildPrMapBySha, buildTitleToPr } from '@/utils/pr-mapping.js';
  */
 export async function runCli(): Promise<void> {
   const argv = await yargs(hideBin(process.argv))
+    // Force English help/messages regardless of system locale
+    .locale('en')
     .option('repo-path', { type: 'string', default: '.' })
     .option('changelog-path', {
       type: 'string',


### PR DESCRIPTION
## Summary

Fix help message to use English.

<!-- A brief summary of the changes -->

## Description

I think that help message should be in English because most programming language is written in English.

<!-- A detailed explanation of the changes, including why they are needed -->
