### PR TITLE
fix: ai used flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,9 +203,9 @@ export async function runCli(): Promise<void> {
       }
     }
     const titlesForLLM = buildTitlesForClassification(parsedRelease.items);
-    const { categories, aiUsed: llmUsed } = await classifyTitles(titlesForLLM, provider.name);
-    // Mark that an LLM was used when classification actually succeeded.
-    aiUsed = aiUsed || llmUsed;
+    let categories = await classifyTitles(titlesForLLM, provider.name);
+    // Mark that an LLM was used when classification ran with a valid provider key.
+    aiUsed = aiUsed || hasProviderKey;
     // Heuristic tuning: ensure typing/contract corrections are grouped under Fixed.
     categories = tuneCategoriesByTitle(parsedRelease.items, categories);
     const section = buildSectionFromRelease({


### PR DESCRIPTION
## Summary

Fix `aiUsed` flag.

<!-- A brief summary of the changes -->

## Description

The `aiUsed` flag doesn't run correctly. 

Even though it is given a proper api key, it shows `Note: Generated without LLM. Reason: Used GitHub Release Notes as the source (no model call).`

<!-- A detailed explanation of the changes, including why they are needed -->
