### PR TITLE
refactor: move llm-parse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import {
   fetchPRInfo,
 } from '@/lib/github.js';
 
-import { parseOrRetryLLMOutput } from '@/schema/llm-parse.js';
+import { parseOrRetryLLMOutput } from '@/utils/llm-parse.js';
 import { CliOptionsSchema } from '@/schema/cli.js';
 import { EnvSchema, ensureGithubTokenRequired } from '@/schema/env.js';
 import { resolveGitHubAuth } from '@/utils/github-auth.js';

--- a/src/utils/llm-parse.ts
+++ b/src/utils/llm-parse.ts
@@ -50,3 +50,4 @@ export async function parseOrRetryLLMOutput(
     'LLM output did not match schema after retry'
   );
 }
+


### PR DESCRIPTION
## Summary

Move llm-parse.

<!-- A brief summary of the changes -->

## Description

Move `llm-parse` to utils. It's not correct in the schema directory.

<!-- A detailed explanation of the changes, including why they are needed -->
