### PR TITLE
chore(action): enforce minimum package age with pnpm dlx

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -23,6 +23,10 @@ on:
       release_body:
         required: false
         type: string
+      minimum_package_age_days:
+        required: false
+        type: string
+        default: '2'
       dry_run:
         required: false
         type: string
@@ -54,6 +58,7 @@ jobs:
           release-tag: ${{ inputs.release_tag }}
           release-name: ${{ inputs.release_name }}
           release-body: ${{ inputs.release_body }}
+          minimum-package-age-days: ${{ inputs.minimum_package_age_days }}
           dry-run: ${{ inputs.dry_run }}
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ npx @nyaomaru/changelog-bot --help
 - During `v0`, breaking changes may occur as we stabilize flags and output. We avoid breaks when possible and document changes in the changelog.
 - To pin versions:
   - Action: use a major tag (`uses: nyaomaru/changelog-bot@v0`) or a specific ref (e.g., `@v0.1.2`).
-  - Action + CLI pin: set `npm-version` input (e.g., `npm-version: 0.1.2`). The action also blocks versions newer than 2 days unless you override `minimum-package-age-days`.
+  - Action + CLI pin: set `npm-version` input (e.g., `npm-version: 0.1.2`). By default, the action blocks versions published less than 2 days ago unless you override `minimum-package-age-days`.
   - npx: `npx @nyaomaru/changelog-bot@0.1.2 ...`.
 - From `v1` onward, we follow SemVer: no breaking changes without a major version bump.
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Outputs: None.
 Security note:
 
 - The published action installs the CLI with `pnpm dlx` and sets pnpm’s `minimumReleaseAge` so versions published less than 2 days earlier are blocked by default.
+- The action passes that setting via pnpm’s CLI config override form, `--config.minimum-release-age=...`, which is the flag shape pnpm accepts at runtime.
 - If you need an emergency rollout, either pin an older exact version or set `minimum-package-age-days: '0'` to disable the guard intentionally.
 - If you run the CLI directly with `npx`, this guard does not apply automatically. Use `pnpm dlx` with `minimumReleaseAge`, or pin an exact version yourself if you want the same protection.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ jobs:
           release-tag: ${{ github.event.release.tag_name }}
           release-name: ${{ github.event.release.tag_name }}
           # npm-version: latest   # optionally pin a version/range
+          # minimum-package-age-days: '2' # block versions published less than 2 days ago
           # dry-run: 'true'       # to avoid writing + PR
         env:
           # Optional: set one of the following to enable AI generation
@@ -225,12 +226,19 @@ Action inputs (for both 1 and 3):
 - `base-branch` / `base_branch`: base branch for PR (default `main`).
 - `provider`: `openai` or `anthropic` (default `openai`).
 - `npm-version` / `npm_version`: npm dist-tag or range for the CLI package (default `latest`).
+- `minimum-package-age-days` / `minimum_package_age_days`: minimum publish age required for the resolved npm package version before the action installs it (default `2`, set to `0` to disable explicitly).
 - `release-tag` / `release_tag`: tag or ref to generate for.
 - `release-name` / `release_name`: display version (without `v`).
 - `release-body` / `release_body`: extra release notes to merge.
 - `dry-run` / `dry_run`: `'true'` to print without writing/PR.
 
 Outputs: None.
+
+Security note:
+
+- The published action installs the CLI with `pnpm dlx` and sets pnpm’s `minimumReleaseAge` so versions published less than 2 days earlier are blocked by default.
+- If you need an emergency rollout, either pin an older exact version or set `minimum-package-age-days: '0'` to disable the guard intentionally.
+- If you run the CLI directly with `npx`, this guard does not apply automatically. Use `pnpm dlx` with `minimumReleaseAge`, or pin an exact version yourself if you want the same protection.
 
 Environment:
 
@@ -393,7 +401,7 @@ npx @nyaomaru/changelog-bot --help
 - During `v0`, breaking changes may occur as we stabilize flags and output. We avoid breaks when possible and document changes in the changelog.
 - To pin versions:
   - Action: use a major tag (`uses: nyaomaru/changelog-bot@v0`) or a specific ref (e.g., `@v0.1.2`).
-  - Action + CLI pin: set `npm-version` input (e.g., `npm-version: 0.1.2`).
+  - Action + CLI pin: set `npm-version` input (e.g., `npm-version: 0.1.2`). The action also blocks versions newer than 2 days unless you override `minimum-package-age-days`.
   - npx: `npx @nyaomaru/changelog-bot@0.1.2 ...`.
 - From `v1` onward, we follow SemVer: no breaking changes without a major version bump.
 

--- a/action.yml
+++ b/action.yml
@@ -66,11 +66,20 @@ runs:
         REPO_FULL_NAME: ${{ github.repository }}
         # Capture release_body safely without inline interpolation issues
         INPUT_RELEASE_BODY: ${{ inputs['release-body'] }}
+        INPUT_MINIMUM_PACKAGE_AGE_DAYS: ${{ inputs['minimum-package-age-days'] }}
       run: |
         set -euo pipefail
-        MINIMUM_PACKAGE_AGE_MINUTES="$(( ${{ inputs['minimum-package-age-days'] }} * 24 * 60 ))"
+
+        if ! [[ "${INPUT_MINIMUM_PACKAGE_AGE_DAYS:-}" =~ ^[0-9]+$ ]]; then
+          echo "::error::Invalid minimum-package-age-days value: '${INPUT_MINIMUM_PACKAGE_AGE_DAYS:-}'. Expected a non-negative integer number of days. Set it to 0 to disable the guard."
+          exit 1
+        fi
+
+        MINIMUM_PACKAGE_AGE_MINUTES="$(( INPUT_MINIMUM_PACKAGE_AGE_DAYS * 24 * 60 ))"
         CMD=(
           pnpm
+          # WHY: pnpm's setting name is `minimumReleaseAge`, but the CLI `--config.*`
+          # override that pnpm accepts here is kebab-cased.
           "--config.minimum-release-age=${MINIMUM_PACKAGE_AGE_MINUTES}"
           dlx
           @nyaomaru/changelog-bot@"${{ inputs.npm-version }}"

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
       run: |
         set -euo pipefail
         corepack enable
-        corepack prepare pnpm@10.12 --activate
+        corepack prepare pnpm@10.12.0 --activate
 
     - name: Run changelog-bot
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -81,8 +81,9 @@ runs:
         CMD=(
           corepack
           pnpm
-          # WHY: pnpm's setting name is `minimumReleaseAge`, but the CLI `--config.*`
-          # override that pnpm accepts here is kebab-cased.
+          # WHY: pnpm documents this setting as `minimumReleaseAge`, but the config key
+          # used in `.npmrc` and with CLI `--config.*` overrides is kebab-cased as
+          # `minimum-release-age`: https://pnpm.io/npmrc#minimumreleaseage
           "--config.minimum-release-age=${MINIMUM_PACKAGE_AGE_MINUTES}"
           dlx
           @nyaomaru/changelog-bot@"${{ inputs.npm-version }}"

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        corepack enable
         corepack prepare pnpm@10.12 --activate
 
     - name: Run changelog-bot
@@ -75,8 +76,10 @@ runs:
           exit 1
         fi
 
-        MINIMUM_PACKAGE_AGE_MINUTES="$(( INPUT_MINIMUM_PACKAGE_AGE_DAYS * 24 * 60 ))"
+        MINIMUM_PACKAGE_AGE_DAYS_BASE10="$(( 10#${INPUT_MINIMUM_PACKAGE_AGE_DAYS} ))"
+        MINIMUM_PACKAGE_AGE_MINUTES="$(( MINIMUM_PACKAGE_AGE_DAYS_BASE10 * 24 * 60 ))"
         CMD=(
+          corepack
           pnpm
           # WHY: pnpm's setting name is `minimumReleaseAge`, but the CLI `--config.*`
           # override that pnpm accepts here is kebab-cased.

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'npm dist-tag or version range for @nyaomaru/changelog-bot'
     required: false
     default: 'latest'
+  minimum-package-age-days:
+    description: 'Minimum age in days required for the npm package version resolved from npm-version'
+    required: false
+    default: '2'
   dry-run:
     description: "If 'true', print updated changelog without writing or PR"
     required: false
@@ -49,6 +53,12 @@ runs:
       with:
         node-version: '22'
 
+    - name: Setup pnpm
+      shell: bash
+      run: |
+        set -euo pipefail
+        corepack prepare pnpm@10.12 --activate
+
     - name: Run changelog-bot
       shell: bash
       env:
@@ -58,8 +68,12 @@ runs:
         INPUT_RELEASE_BODY: ${{ inputs['release-body'] }}
       run: |
         set -euo pipefail
+        MINIMUM_PACKAGE_AGE_MINUTES="$(( ${{ inputs['minimum-package-age-days'] }} * 24 * 60 ))"
         CMD=(
-          npx -y @nyaomaru/changelog-bot@"${{ inputs.npm-version }}"
+          pnpm
+          "--config.minimum-release-age=${MINIMUM_PACKAGE_AGE_MINUTES}"
+          dlx
+          @nyaomaru/changelog-bot@"${{ inputs.npm-version }}"
           --changelog-path "${{ inputs['changelog-path'] }}"
           --base-branch "${{ inputs['base-branch'] }}"
           --provider "${{ inputs.provider }}"


### PR DESCRIPTION
## Summary

Enforce minimum package age with pnpm dlx

<!-- A brief summary of the changes -->

## Description

Switch the GitHub Action from `npx` to `pnpm dlx` and enforce a minimum package publish age using pnpm’s native `minimumReleaseAge` setting. 

This adds a default 2-day delay before newly published package versions can be installed, reduces supply-chain risk without custom registry logic, and keeps the guard configurable through the action and reusable workflow inputs.

`README` examples and action docs were updated to describe the new behavior and the explicit override path.

<!-- A detailed explanation of the changes, including why they are needed -->
