### PR TITLE
refactor: extract changelog CLI workflow helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,25 @@
-import {
-  tryDetectLatestTag,
-  tryDetectPrevTag,
-  firstCommit,
-  gitMergedPRs,
-  commitsInRange,
-  dateForRef,
-} from '@/lib/git.js';
-import {
-  readChangelog,
-  writeChangelog,
-  ensureCompareLinks,
-  computeChangelog,
-} from '@/lib/changelog.js';
+import { gitMergedPRs, commitsInRange } from '@/lib/git.js';
+import { writeChangelog } from '@/lib/changelog.js';
 import { createPR } from '@/lib/pr.js';
 import { mapCommitsToPrs, fetchReleaseBody } from '@/lib/github.js';
 
-import { EnvSchema, ensureGithubTokenRequired } from '@/schema/env.js';
-import { resolveGitHubAuth } from '@/utils/github-auth.js';
-
-import type { LLMOutput } from '@/types/llm.js';
-import { postprocessSection } from '@/utils/section-postprocess.js';
-import { FULL_CHANGELOG_RE } from '@/constants/release.js';
+import { ensureGithubTokenRequired } from '@/schema/env.js';
 import { providerFactory } from '@/utils/provider.js';
 import { getRepoFullName } from '@/utils/repository.js';
-import { versionFromRef } from '@/utils/version.js';
-import { escapeRegExp } from '@/utils/escape.js';
 import { parseCliArgs } from '@/lib/cli-args.js';
 import { buildChangelogLlmOutput } from '@/utils/llm-output.js';
+import {
+  prepareExistingChangelog,
+  resolveReleasePlan,
+  resolveRunCredentials,
+} from '@/lib/release-context.js';
+import { finalizeChangelogUpdate } from '@/lib/changelog-update.js';
 
-import { HEAD_REF } from '@/constants/git.js';
 import {
   DEFAULT_PR_LABELS,
   PR_BRANCH_PREFIX,
   PR_TITLE_PREFIX,
 } from '@/constants/changelog.js';
-import { DATE_YYYY_MM_DD_LEN } from '@/constants/time.js';
-import { sanitizeLLMOutput } from '@/utils/sanitize.js';
 import { buildPrMapBySha, buildTitleToPr } from '@/utils/pr-mapping.js';
 
 /**
@@ -44,47 +28,29 @@ import { buildPrMapBySha, buildTitleToPr } from '@/utils/pr-mapping.js';
  */
 export async function runCli(): Promise<void> {
   const cli = await parseCliArgs(process.argv);
-
-  const repoPath = cli.repoPath;
   const provider = providerFactory(cli.provider);
-  const [owner, repo] = getRepoFullName().split('/');
-
-  // Resolve refs
-  const releaseRef = cli.releaseTag || tryDetectLatestTag(repoPath) || HEAD_REF;
-  const version = cli.releaseName || versionFromRef(releaseRef);
-  const prevRef =
-    tryDetectPrevTag(releaseRef, repoPath) || firstCommit(repoPath);
-
-  // Inputs
-  // Prefer the release/tag commit date for CHANGELOG entries; fallback to today when unavailable.
-  const date =
-    dateForRef(releaseRef, repoPath) ||
-    new Date().toISOString().slice(0, DATE_YYYY_MM_DD_LEN);
+  const {
+    owner,
+    repo,
+    repoPath,
+    changelogPath,
+    releaseRef,
+    version,
+    prevRef,
+    date,
+  } = resolveReleasePlan(cli, getRepoFullName());
   const prs = gitMergedPRs(prevRef, releaseRef, repoPath);
-  const changelogPath = cli.changelogPath;
-  let existing = readChangelog(changelogPath);
-  existing = existing.replace(
-    new RegExp(`\n[v${escapeRegExp(version)}]: .*\n?`, 'g'),
-    '\n',
-  );
+  const existing = prepareExistingChangelog(changelogPath, version);
 
   const commitList = commitsInRange(prevRef, releaseRef, repoPath);
-  const commitShas = commitList.map((c) => c.sha);
+  const commitShas = commitList.map((commit) => commit.sha);
 
   let apiPrMap: Record<string, { number: number }[]> = {};
-  const envParsed = EnvSchema.safeParse(process.env);
-  // Resolve GitHub auth: prefer PAT, then GitHub App token
-  const ghAuth = await resolveGitHubAuth(owner, repo);
-  const token = ghAuth?.token;
-  const hasProviderKey = (() => {
-    const openai = envParsed.success
-      ? envParsed.data.OPENAI_API_KEY
-      : process.env.OPENAI_API_KEY;
-    const anthropic = envParsed.success
-      ? envParsed.data.ANTHROPIC_API_KEY
-      : process.env.ANTHROPIC_API_KEY;
-    return provider.name === 'openai' ? Boolean(openai) : Boolean(anthropic);
-  })();
+  const { token, hasProviderKey } = await resolveRunCredentials(
+    provider.name,
+    owner,
+    repo,
+  );
   if (token) {
     apiPrMap = await mapCommitsToPrs(owner, repo, commitShas, token);
   }
@@ -118,55 +84,18 @@ export async function runCli(): Promise<void> {
     token,
   });
 
-  // Unify LLM output sanitization across both paths (release-notes/LLM/fallback).
-  // Type guard: logic above guarantees llm is set; enforce at runtime for safety.
-  if (!llm) throw new Error('Internal error: LLM output was not constructed');
-  llm = sanitizeLLMOutput(llm) as LLMOutput;
-
-  if (llm.new_section_markdown) {
-    llm.new_section_markdown = postprocessSection(
-      llm.new_section_markdown,
-      titleToPr,
-      { owner, repo },
-    );
-  }
-
-  const { compareLine, unreleasedLine } = ensureCompareLinks({
+  const finalizedUpdate = finalizeChangelogUpdate({
     owner,
     repo,
-    prevTag: prevRef,
+    version,
+    prevRef,
     releaseRef,
-    version,
     existing,
+    llm,
+    titleToPr,
   });
-
-  const compare = llm.compare_link_line ?? compareLine;
-  if (llm.new_section_markdown && compare) {
-    const ref = `[v${version}]:`;
-    if (!llm.new_section_markdown.includes(ref)) {
-      llm.new_section_markdown = `${llm.new_section_markdown}\n${compare}`;
-    }
-  }
-
-  // Ensure Full Changelog line exists when release notes were not used or missing.
-  if (
-    llm.new_section_markdown &&
-    !FULL_CHANGELOG_RE.test(llm.new_section_markdown)
-  ) {
-    const fullUrl = `https://github.com/${owner}/${repo}/compare/${encodeURIComponent(
-      prevRef,
-    )}...${encodeURIComponent(releaseRef)}`;
-    llm.new_section_markdown = `${llm.new_section_markdown}\n**Full Changelog**: ${fullUrl}\n`;
-  }
-
-  // Compute next changelog content (pure function)
-  const updated = computeChangelog(existing, {
-    version,
-    newSection: llm.new_section_markdown,
-    insertAfterAnchor: llm.insert_after_anchor!,
-    compareLine: undefined, // compare ref already embedded in section
-    unreleasedLine: llm.unreleased_compare_update ?? unreleasedLine,
-  });
+  llm = finalizedUpdate.llm;
+  const updated = finalizedUpdate.updated;
 
   // Dry run: print result without writing or PR
   if (cli.dryRun) {

--- a/src/lib/changelog-update.ts
+++ b/src/lib/changelog-update.ts
@@ -1,0 +1,116 @@
+import { computeChangelog, ensureCompareLinks } from '@/lib/changelog.js';
+import type { LLMOutput } from '@/types/llm.js';
+import { postprocessSection } from '@/utils/section-postprocess.js';
+import { sanitizeLLMOutput } from '@/utils/sanitize.js';
+import { FULL_CHANGELOG_RE } from '@/constants/release.js';
+
+type TitleToPrMap = Record<string, number>;
+
+/** Inputs required to finalize the generated changelog section. */
+export type FinalizeChangelogUpdateParams = {
+  /** Repository owner or org. */
+  owner: string;
+  /** Repository name. */
+  repo: string;
+  /** Release version without the leading `v`. */
+  version: string;
+  /** Previous ref used for compare links. */
+  prevRef: string;
+  /** Current release ref or tag. */
+  releaseRef: string;
+  /** Existing changelog content before the update. */
+  existing: string;
+  /** Structured LLM output to normalize and apply. */
+  llm: LLMOutput;
+  /** Title to PR number mapping used for section post-processing. */
+  titleToPr: TitleToPrMap;
+};
+
+/** Finalized changelog artifacts ready for printing or writing to disk. */
+export type FinalizeChangelogUpdateResult = {
+  /** Sanitized LLM output after section post-processing. */
+  llm: LLMOutput;
+  /** Updated changelog content. */
+  updated: string;
+};
+
+function ensureCompareLineInSection(
+  sectionMarkdown: string,
+  version: string,
+  compareLine: string,
+): string {
+  const compareReference = `[v${version}]:`;
+  if (sectionMarkdown.includes(compareReference)) return sectionMarkdown;
+  return `${sectionMarkdown}\n${compareLine}`;
+}
+
+function ensureFullChangelogLine(
+  sectionMarkdown: string,
+  owner: string,
+  repo: string,
+  prevRef: string,
+  releaseRef: string,
+): string {
+  if (FULL_CHANGELOG_RE.test(sectionMarkdown)) return sectionMarkdown;
+
+  const fullChangelogUrl = `https://github.com/${owner}/${repo}/compare/${encodeURIComponent(
+    prevRef,
+  )}...${encodeURIComponent(releaseRef)}`;
+  return `${sectionMarkdown}\n**Full Changelog**: ${fullChangelogUrl}\n`;
+}
+
+/**
+ * Sanitize the generated release section and compute the next changelog content.
+ * WHY: Keeping post-processing and compare-link logic in one pure function
+ * makes the CLI orchestration easier to read and easier to test.
+ * @param params Existing changelog state and generated section metadata.
+ * @returns Sanitized LLM output and the fully updated changelog text.
+ */
+export function finalizeChangelogUpdate(
+  params: FinalizeChangelogUpdateParams,
+): FinalizeChangelogUpdateResult {
+  const { owner, repo, version, prevRef, releaseRef, existing, titleToPr } =
+    params;
+
+  const finalizedLlm = sanitizeLLMOutput(params.llm) as LLMOutput;
+  finalizedLlm.new_section_markdown = postprocessSection(
+    finalizedLlm.new_section_markdown,
+    titleToPr,
+    { owner, repo },
+  );
+
+  const { compareLine, unreleasedLine } = ensureCompareLinks({
+    owner,
+    repo,
+    prevTag: prevRef,
+    releaseRef,
+    version,
+    existing,
+  });
+
+  finalizedLlm.new_section_markdown = ensureCompareLineInSection(
+    finalizedLlm.new_section_markdown,
+    version,
+    finalizedLlm.compare_link_line ?? compareLine,
+  );
+  finalizedLlm.new_section_markdown = ensureFullChangelogLine(
+    finalizedLlm.new_section_markdown,
+    owner,
+    repo,
+    prevRef,
+    releaseRef,
+  );
+
+  const updated = computeChangelog(existing, {
+    version,
+    newSection: finalizedLlm.new_section_markdown,
+    insertAfterAnchor: finalizedLlm.insert_after_anchor!,
+    compareLine: undefined,
+    unreleasedLine: finalizedLlm.unreleased_compare_update ?? unreleasedLine,
+  });
+
+  return {
+    llm: finalizedLlm,
+    updated,
+  };
+}

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -8,9 +8,68 @@ import {
 import type { CreatePRParams } from '@/types/pr.js';
 
 type GitArgs = readonly [string, ...string[]];
+const INVALID_BRANCH_PUNCTUATION = ' ~^:?*[';
 
 function runGit(args: GitArgs): void {
   execFileSync('git', args, EXEC_OPTS);
+}
+
+function hasInvalidBranchChars(branchName: string): boolean {
+  for (const character of branchName) {
+    const charCode = character.charCodeAt(0);
+    if (charCode <= 0x1f || charCode === 0x7f) {
+      return true;
+    }
+    if (INVALID_BRANCH_PUNCTUATION.includes(character)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function assertSafeBranchName(branchName: string): void {
+  if (!branchName) {
+    throw new Error('Invalid branch name: branch name must not be empty.');
+  }
+  if (branchName.startsWith('-')) {
+    throw new Error(
+      'Invalid branch name: branch name must not start with "-".',
+    );
+  }
+  if (
+    branchName.startsWith('/') ||
+    branchName.endsWith('/') ||
+    branchName.includes('//') ||
+    branchName.includes('..') ||
+    branchName.includes('@{') ||
+    branchName.includes('\\') ||
+    branchName.endsWith('.') ||
+    hasInvalidBranchChars(branchName)
+  ) {
+    throw new Error(`Invalid branch name: "${branchName}" is not a valid ref.`);
+  }
+
+  const branchSegments = branchName.split('/');
+  if (
+    branchSegments.some(
+      (segment) =>
+        !segment ||
+        segment.startsWith('.') ||
+        segment.endsWith('.lock') ||
+        segment.endsWith('.'),
+    )
+  ) {
+    throw new Error(`Invalid branch name: "${branchName}" is not a valid ref.`);
+  }
+}
+
+function assertSafeChangelogPath(changelogPath: string): void {
+  if (!changelogPath) {
+    throw new Error('Invalid changelog path: path must not be empty.');
+  }
+  if (changelogPath.includes('\0')) {
+    throw new Error('Invalid changelog path: null byte is not allowed.');
+  }
 }
 
 /**
@@ -35,11 +94,18 @@ export async function createPR(params: CreatePRParams) {
   const octokit = new Octokit({ auth: token });
   const changelogPath = changelogEntry || DEFAULT_CHANGELOG_FILE;
 
+  // WHY: These values originate from CLI/config inputs. Rejecting unsafe branch
+  // refs here and terminating `git add` option parsing below prevents values
+  // like `--force` or `--all` from being interpreted as git flags.
+  assertSafeBranchName(branchName);
+  assertSafeChangelogPath(changelogPath);
+
   // WHY: Use argv arrays instead of shell strings so paths and titles with
-  // whitespace or quotes are passed to Git without manual escaping.
+  // whitespace or quotes are passed to Git without manual escaping. The `--`
+  // terminator keeps Git from treating changelog paths like `--all` as options.
   const commands: GitArgs[] = [
     ['checkout', '-b', branchName],
-    ['add', changelogPath],
+    ['add', '--', changelogPath],
     ['commit', '-m', title],
     ['push', GIT_REMOTE, branchName],
   ];

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -1,12 +1,17 @@
 import { Octokit } from 'octokit';
-import { execSync } from 'node:child_process';
-import { escapeQuotes } from '@/utils/escape.js';
+import { execFileSync } from 'node:child_process';
 import {
   DEFAULT_CHANGELOG_FILE,
   EXEC_OPTS,
   GIT_REMOTE,
 } from '@/constants/git.js';
 import type { CreatePRParams } from '@/types/pr.js';
+
+type GitArgs = readonly [string, ...string[]];
+
+function runGit(args: GitArgs): void {
+  execFileSync('git', args, EXEC_OPTS);
+}
 
 /**
  * Create a pull request that commits the changelog and pushes a new branch.
@@ -30,14 +35,15 @@ export async function createPR(params: CreatePRParams) {
   const octokit = new Octokit({ auth: token });
   const changelogPath = changelogEntry || DEFAULT_CHANGELOG_FILE;
 
-  // WHY: Keep the sequence explicit and linear; escape commit message quotes.
-  const commands = [
-    `git checkout -b ${branchName}`,
-    `git add ${changelogPath}`,
-    `git commit -m "${escapeQuotes(title)}"`,
-    `git push ${GIT_REMOTE} ${branchName}`,
+  // WHY: Use argv arrays instead of shell strings so paths and titles with
+  // whitespace or quotes are passed to Git without manual escaping.
+  const commands: GitArgs[] = [
+    ['checkout', '-b', branchName],
+    ['add', changelogPath],
+    ['commit', '-m', title],
+    ['push', GIT_REMOTE, branchName],
   ];
-  for (const command of commands) execSync(command, EXEC_OPTS);
+  for (const commandArgs of commands) runGit(commandArgs);
 
   const pullRequest = await octokit.rest.pulls.create({
     owner,

--- a/src/lib/release-context.ts
+++ b/src/lib/release-context.ts
@@ -1,0 +1,130 @@
+import {
+  tryDetectLatestTag,
+  tryDetectPrevTag,
+  firstCommit,
+  dateForRef,
+} from '@/lib/git.js';
+import { readChangelog } from '@/lib/changelog.js';
+import { EnvSchema } from '@/schema/env.js';
+import type { CliOptions } from '@/schema/cli.js';
+import type { ProviderName } from '@/types/llm.js';
+import { resolveGitHubAuth } from '@/utils/github-auth.js';
+import { versionFromRef } from '@/utils/version.js';
+import { escapeRegExp } from '@/utils/escape.js';
+import { HEAD_REF } from '@/constants/git.js';
+import { DATE_YYYY_MM_DD_LEN } from '@/constants/time.js';
+import { PROVIDER_OPENAI } from '@/constants/provider.js';
+
+/** Derived release metadata used across the CLI workflow. */
+export type ReleasePlan = {
+  /** Repository owner parsed from `owner/repo`. */
+  owner: string;
+  /** Repository name parsed from `owner/repo`. */
+  repo: string;
+  /** Path to the git repository to inspect. */
+  repoPath: string;
+  /** Path to the changelog file to update. */
+  changelogPath: string;
+  /** Git ref that identifies the current release. */
+  releaseRef: string;
+  /** Release version without the leading `v`. */
+  version: string;
+  /** Previous ref used for compare links and commit ranges. */
+  prevRef: string;
+  /** Release date in `YYYY-MM-DD` format. */
+  date: string;
+};
+
+/** Auth and provider availability resolved for a CLI run. */
+export type RunCredentials = {
+  /** GitHub token resolved from PAT or GitHub App auth. */
+  token?: string;
+  /** Whether the selected provider has an API key configured. */
+  hasProviderKey: boolean;
+};
+
+function getProviderApiKey(
+  providerName: ProviderName,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const parsedEnv = EnvSchema.safeParse(env);
+  const openAiApiKey = parsedEnv.success
+    ? parsedEnv.data.OPENAI_API_KEY
+    : env.OPENAI_API_KEY;
+  const anthropicApiKey = parsedEnv.success
+    ? parsedEnv.data.ANTHROPIC_API_KEY
+    : env.ANTHROPIC_API_KEY;
+  return providerName === PROVIDER_OPENAI ? openAiApiKey : anthropicApiKey;
+}
+
+/**
+ * Resolve release refs, version, and date from CLI options and repository state.
+ * @param cli Validated CLI options.
+ * @param repoFullName Repository identifier in `owner/repo` format.
+ * @returns Normalized release metadata used by the CLI workflow.
+ */
+export function resolveReleasePlan(
+  cli: CliOptions,
+  repoFullName: string,
+): ReleasePlan {
+  const [owner, repo] = repoFullName.split('/');
+  const releaseRef =
+    cli.releaseTag || tryDetectLatestTag(cli.repoPath) || HEAD_REF;
+  const version = cli.releaseName || versionFromRef(releaseRef);
+  const prevRef =
+    tryDetectPrevTag(releaseRef, cli.repoPath) || firstCommit(cli.repoPath);
+  const date =
+    dateForRef(releaseRef, cli.repoPath) ||
+    new Date().toISOString().slice(0, DATE_YYYY_MM_DD_LEN);
+
+  return {
+    owner,
+    repo,
+    repoPath: cli.repoPath,
+    changelogPath: cli.changelogPath,
+    releaseRef,
+    version,
+    prevRef,
+    date,
+  };
+}
+
+/**
+ * Read the changelog and remove any existing compare link for the target version.
+ * WHY: The release section already embeds the compare link, so stale bottom links
+ * must be removed before recomputing the changelog to keep reruns idempotent.
+ * @param changelogPath Path to the changelog file on disk.
+ * @param version Release version without the leading `v`.
+ * @returns Existing changelog text with the target version link removed.
+ */
+export function prepareExistingChangelog(
+  changelogPath: string,
+  version: string,
+): string {
+  const existingChangelog = readChangelog(changelogPath);
+  return existingChangelog.replace(
+    new RegExp(`\n\\[v${escapeRegExp(version)}\\]: .*\n?`, 'g'),
+    '\n',
+  );
+}
+
+/**
+ * Resolve GitHub auth and provider API-key availability for the current run.
+ * @param providerName Selected provider identifier.
+ * @param owner Repository owner or org.
+ * @param repo Repository name.
+ * @param env Environment variables to inspect for provider credentials.
+ * @returns Token and provider-key availability for the workflow.
+ */
+export async function resolveRunCredentials(
+  providerName: ProviderName,
+  owner: string,
+  repo: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<RunCredentials> {
+  const gitHubAuth = await resolveGitHubAuth(owner, repo);
+  return {
+    token: gitHubAuth?.token,
+    hasProviderKey: Boolean(getProviderApiKey(providerName, env)),
+  };
+}

--- a/tests/lib/changelog-update.test.ts
+++ b/tests/lib/changelog-update.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import { test, expect } from '@jest/globals';
+import { finalizeChangelogUpdate } from '@/lib/changelog-update.js';
+
+test('finalizes a generated section with compare links and full changelog url', () => {
+  const result = finalizeChangelogUpdate({
+    owner: 'octo',
+    repo: 'repo',
+    version: '1.1.0',
+    prevRef: 'v1.0.0',
+    releaseRef: 'v1.1.0',
+    existing: ['# Changelog', '', '## [Unreleased]', ''].join('\n'),
+    llm: {
+      new_section_markdown: [
+        '## [v1.1.0] - 2026-04-10',
+        '',
+        '### Added',
+        '- feature',
+      ].join('\n'),
+      insert_after_anchor: '## [Unreleased]',
+      pr_title: 'docs(changelog): v1.1.0',
+      pr_body: 'body',
+    },
+    titleToPr: {},
+  });
+
+  expect(result.llm.new_section_markdown).toContain(
+    '[v1.1.0]: https://github.com/octo/repo/compare/v1.0.0...v1.1.0',
+  );
+  expect(result.llm.new_section_markdown).toContain(
+    '**Full Changelog**: https://github.com/octo/repo/compare/v1.0.0...v1.1.0',
+  );
+  expect(result.updated).toContain('## [v1.1.0] - 2026-04-10');
+});

--- a/tests/lib/create-pr.test.ts
+++ b/tests/lib/create-pr.test.ts
@@ -7,7 +7,6 @@ const {
   beforeEach,
 } = await import('@jest/globals');
 
-type ExecFileSyncFunction = typeof import('node:child_process').execFileSync;
 type JestEnvironment = typeof jestGlobal;
 
 // Mocks
@@ -22,8 +21,7 @@ const unstableMockModule = (
 ).unstable_mockModule;
 
 await unstableMockModule('node:child_process', () => ({
-  execFileSync: (...args: Parameters<ExecFileSyncFunction>) =>
-    execFileSyncMock(...args),
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
 }));
 
 const pullsCreate = jestGlobal.fn(async () => ({ data: { number: 42 } }));
@@ -70,7 +68,7 @@ describe('lib/pr.createPR', () => {
     expect(execFileSyncMock).toHaveBeenNthCalledWith(
       2,
       'git',
-      ['add', 'CHANGELOG.md'],
+      ['add', '--', 'CHANGELOG.md'],
       { stdio: 'inherit' },
     );
     expect(execFileSyncMock).toHaveBeenNthCalledWith(
@@ -124,7 +122,7 @@ describe('lib/pr.createPR', () => {
       owner: 'o',
       repo: 'r',
       baseBranch: 'main',
-      branchName: 'feat/release notes',
+      branchName: 'feat/release-notes',
       title: 'docs(changelog): "quoted" title',
       body: '',
       labels: [],
@@ -135,7 +133,7 @@ describe('lib/pr.createPR', () => {
     expect(execFileSyncMock).toHaveBeenNthCalledWith(
       2,
       'git',
-      ['add', 'docs/Release Notes.md'],
+      ['add', '--', 'docs/Release Notes.md'],
       { stdio: 'inherit' },
     );
     expect(execFileSyncMock).toHaveBeenNthCalledWith(
@@ -144,5 +142,45 @@ describe('lib/pr.createPR', () => {
       ['commit', '-m', 'docs(changelog): "quoted" title'],
       { stdio: 'inherit' },
     );
+  });
+
+  test('treats changelog paths beginning with dash as path arguments', async () => {
+    await createPR({
+      owner: 'o',
+      repo: 'r',
+      baseBranch: 'main',
+      branchName: 'feat/x',
+      title: 'title',
+      body: '',
+      labels: [],
+      token: 't',
+      changelogEntry: '--all',
+    });
+
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['add', '--', '--all'],
+      { stdio: 'inherit' },
+    );
+  });
+
+  test('rejects branch names that start with dash before invoking git', async () => {
+    await expect(
+      createPR({
+        owner: 'o',
+        repo: 'r',
+        baseBranch: 'main',
+        branchName: '--force',
+        title: 'title',
+        body: '',
+        labels: [],
+        token: 't',
+        changelogEntry: 'CHANGELOG.md',
+      }),
+    ).rejects.toThrow('Invalid branch name');
+
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(pullsCreate).not.toHaveBeenCalled();
   });
 });

--- a/tests/lib/create-pr.test.ts
+++ b/tests/lib/create-pr.test.ts
@@ -7,11 +7,11 @@ const {
   beforeEach,
 } = await import('@jest/globals');
 
-type ExecSyncFunction = typeof import('node:child_process').execSync;
+type ExecFileSyncFunction = typeof import('node:child_process').execFileSync;
 type JestEnvironment = typeof jestGlobal;
 
 // Mocks
-const execSyncMock = jestGlobal.fn();
+const execFileSyncMock = jestGlobal.fn();
 type UnstableMockModule = (
   ...args: Parameters<typeof jestGlobal.mock>
 ) => ReturnType<typeof jestGlobal.mock>;
@@ -22,7 +22,8 @@ const unstableMockModule = (
 ).unstable_mockModule;
 
 await unstableMockModule('node:child_process', () => ({
-  execSync: (...args: Parameters<ExecSyncFunction>) => execSyncMock(...args),
+  execFileSync: (...args: Parameters<ExecFileSyncFunction>) =>
+    execFileSyncMock(...args),
 }));
 
 const pullsCreate = jestGlobal.fn(async () => ({ data: { number: 42 } }));
@@ -41,7 +42,7 @@ const { createPR } = await import('@/lib/pr.js');
 
 describe('lib/pr.createPR', () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     pullsCreate.mockClear();
     addLabels.mockClear();
   });
@@ -59,7 +60,31 @@ describe('lib/pr.createPR', () => {
       changelogEntry: 'CHANGELOG.md',
     });
 
-    expect(execSyncMock).toHaveBeenCalledTimes(4);
+    expect(execFileSyncMock).toHaveBeenCalledTimes(4);
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['checkout', '-b', 'chore/changelog-v1.0.0'],
+      { stdio: 'inherit' },
+    );
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['add', 'CHANGELOG.md'],
+      { stdio: 'inherit' },
+    );
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      3,
+      'git',
+      ['commit', '-m', 'docs(changelog): v1.0.0'],
+      { stdio: 'inherit' },
+    );
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      4,
+      'git',
+      ['push', 'origin', 'chore/changelog-v1.0.0'],
+      { stdio: 'inherit' },
+    );
     expect(pullsCreate).toHaveBeenCalledWith({
       owner: 'o',
       repo: 'r',
@@ -92,5 +117,32 @@ describe('lib/pr.createPR', () => {
     });
 
     expect(addLabels).not.toHaveBeenCalled();
+  });
+
+  test('passes titles and changelog paths without shell escaping', async () => {
+    await createPR({
+      owner: 'o',
+      repo: 'r',
+      baseBranch: 'main',
+      branchName: 'feat/release notes',
+      title: 'docs(changelog): "quoted" title',
+      body: '',
+      labels: [],
+      token: 't',
+      changelogEntry: 'docs/Release Notes.md',
+    });
+
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['add', 'docs/Release Notes.md'],
+      { stdio: 'inherit' },
+    );
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      3,
+      'git',
+      ['commit', '-m', 'docs(changelog): "quoted" title'],
+      { stdio: 'inherit' },
+    );
   });
 });

--- a/tests/lib/release-context.test.ts
+++ b/tests/lib/release-context.test.ts
@@ -1,0 +1,94 @@
+// @ts-nocheck
+import { describe, expect, test, jest } from '@jest/globals';
+
+const tryDetectLatestTag = jest.fn();
+const tryDetectPrevTag = jest.fn();
+const firstCommit = jest.fn();
+const dateForRef = jest.fn();
+const readChangelog = jest.fn();
+const resolveGitHubAuth = jest.fn();
+
+await jest.unstable_mockModule('@/lib/git.js', () => ({
+  tryDetectLatestTag,
+  tryDetectPrevTag,
+  firstCommit,
+  dateForRef,
+}));
+
+await jest.unstable_mockModule('@/lib/changelog.js', () => ({
+  readChangelog,
+}));
+
+await jest.unstable_mockModule('@/utils/github-auth.js', () => ({
+  resolveGitHubAuth,
+}));
+
+const { resolveReleasePlan, prepareExistingChangelog, resolveRunCredentials } =
+  await import('@/lib/release-context.js');
+
+describe('lib/release-context', () => {
+  test('resolves release metadata from repo state when flags are omitted', () => {
+    tryDetectLatestTag.mockReturnValue('v1.2.0');
+    tryDetectPrevTag.mockReturnValue('v1.1.0');
+    firstCommit.mockReturnValue('abc1234');
+    dateForRef.mockReturnValue('2026-04-10');
+
+    const plan = resolveReleasePlan(
+      {
+        repoPath: '/repo',
+        changelogPath: 'CHANGELOG.md',
+        baseBranch: 'main',
+        provider: 'openai',
+        releaseTag: undefined,
+        releaseName: undefined,
+        releaseBody: '',
+        dryRun: false,
+      },
+      'octo/repo',
+    );
+
+    expect(plan).toEqual({
+      owner: 'octo',
+      repo: 'repo',
+      repoPath: '/repo',
+      changelogPath: 'CHANGELOG.md',
+      releaseRef: 'v1.2.0',
+      version: '1.2.0',
+      prevRef: 'v1.1.0',
+      date: '2026-04-10',
+    });
+  });
+
+  test('removes an existing compare link for the current version', () => {
+    readChangelog.mockReturnValue(
+      [
+        '# Changelog',
+        '',
+        '## [v1.2.0]',
+        '- change',
+        '',
+        '[v1.2.0]: https://example.com/compare/v1.1.0...v1.2.0',
+        '[v1.1.0]: https://example.com/compare/v1.0.0...v1.1.0',
+      ].join('\n'),
+    );
+
+    const existing = prepareExistingChangelog('CHANGELOG.md', '1.2.0');
+
+    expect(existing).not.toContain('[v1.2.0]:');
+    expect(existing).toContain('[v1.1.0]:');
+  });
+
+  test('resolves GitHub auth and provider-key availability', async () => {
+    resolveGitHubAuth.mockResolvedValue({ token: 'gh-token', source: 'pat' });
+
+    const credentials = await resolveRunCredentials('openai', 'octo', 'repo', {
+      OPENAI_API_KEY: 'openai-key',
+    });
+
+    expect(resolveGitHubAuth).toHaveBeenCalledWith('octo', 'repo');
+    expect(credentials).toEqual({
+      token: 'gh-token',
+      hasProviderKey: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extract changelog CLI workflow helpers.

<!-- A brief summary of the changes -->

## Description

Refactor the CLI release flow into smaller, testable helpers and harden PR git execution. 

This extracts release-context resolution and changelog finalization out of `src/index.ts`, switches PR git commands to argument-based subprocess calls, and adds focused tests for the new workflow boundaries and safer command handling.

<!-- A detailed explanation of the changes, including why they are needed -->
