### PR TITLE
refactor(utils): extract shared markdown and title lookup helpers

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,9 +1,7 @@
 model_reasoning_effort = "high"
 hide_agent_reasoning = true
 network_access = true
-
-[features]
-web_search_request = true
+web_search = "live"
 
 [mcp_servers.serena]
 command = "uvx"

--- a/src/utils/attach-pr.ts
+++ b/src/utils/attach-pr.ts
@@ -2,7 +2,7 @@
 // conventional commit prefix (with optional scope) to compare plain subjects.
 import { isBulletLine } from '@/utils/is.js';
 import { INLINE_PR_PRESENT_RE } from '@/constants/conventional.js';
-import { normalizeTitle } from '@/utils/title-normalize.js';
+import { buildTitleLookup, findTitleMatch } from '@/utils/title-lookup.js';
 
 /** Maps original PR titles to their numeric identifiers. */
 type TitleToPr = Record<string, number>;
@@ -24,32 +24,6 @@ function hasInlinePrReference(line: string): boolean {
 }
 
 /**
- * Build a map keyed by normalized titles for efficient fuzzy matching.
- * @param titleToPr Original title-to-PR map.
- * @returns Map keyed by normalized titles.
- */
-function buildNormalizedLookup(titleToPr: TitleToPr): Map<string, number> {
-  const normalized = new Map<string, number>();
-  for (const [originalTitle, prNumber] of Object.entries(titleToPr)) {
-    const key = normalizeTitle(originalTitle);
-    if (normalized.has(key)) {
-      const existing = normalized.get(key)!;
-      // WHY: Collisions happen when titles differ only by punctuation/case.
-      // Prefer the higher PR number (usually newer) and log for visibility.
-      if (prNumber !== existing) {
-        console.warn(
-          `Title collision: "${originalTitle}" -> "${key}" (PR #${prNumber} vs #${existing})`,
-        );
-      }
-      normalized.set(key, Math.max(existing, prNumber));
-    } else {
-      normalized.set(key, prNumber);
-    }
-  }
-  return normalized;
-}
-
-/**
  * Split a markdown bullet line into prefix ("- ") and text segments.
  * @param line Markdown line to split.
  * @returns Bullet fragments or `undefined` when the line is not a bullet.
@@ -59,30 +33,6 @@ function splitBulletLine(line: string): BulletParts | undefined {
   if (!bulletMatch) return undefined;
   const [, prefix, text] = bulletMatch;
   return { prefix, text };
-}
-
-/**
- * Find a PR number whose normalized title matches the bullet text (prefix matching both ways).
- * @param normalizedBulletText Normalized bullet content.
- * @param normalizedTitleToPr Map of normalized titles to PR numbers.
- * @returns Matching PR number when found.
- */
-function findMatchingPrNumber(
-  normalizedBulletText: string,
-  normalizedTitleToPr: Map<string, number>,
-): number | undefined {
-  const direct = normalizedTitleToPr.get(normalizedBulletText);
-  if (direct) return direct;
-
-  for (const [normalizedTitle, prNumber] of normalizedTitleToPr) {
-    if (
-      normalizedBulletText.startsWith(normalizedTitle) ||
-      normalizedTitle.startsWith(normalizedBulletText)
-    ) {
-      return prNumber;
-    }
-  }
-  return undefined;
 }
 
 /**
@@ -97,7 +47,29 @@ export function attachPrNumbers(
   titleToPr: TitleToPr,
   repo?: { owner: string; repo: string },
 ): string {
-  const normalizedTitleToPr = buildNormalizedLookup(titleToPr);
+  const titleLookup = buildTitleLookup(
+    Object.entries(titleToPr).map(([title, prNumber]) => ({
+      titles: [title],
+      value: prNumber,
+    })),
+    {
+      onNormalizedCollision: ({
+        title,
+        normalizedTitle,
+        existingValue,
+        incomingValue,
+      }) => {
+        // WHY: Collisions happen when titles differ only by punctuation/case.
+        // Prefer the higher PR number (usually newer) and log for visibility.
+        if (incomingValue !== existingValue) {
+          console.warn(
+            `Title collision: "${title}" -> "${normalizedTitle}" (PR #${incomingValue} vs #${existingValue})`,
+          );
+        }
+        return Math.max(existingValue, incomingValue);
+      },
+    },
+  );
 
   const lines = md.split('\n');
   const updated = lines.map((line) => {
@@ -107,11 +79,7 @@ export function attachPrNumbers(
     const bulletParts = splitBulletLine(line);
     if (!bulletParts) return line;
 
-    const normalizedBulletText = normalizeTitle(bulletParts.text);
-    const matchedPrNumber = findMatchingPrNumber(
-      normalizedBulletText,
-      normalizedTitleToPr,
-    );
+    const matchedPrNumber = findTitleMatch(bulletParts.text, titleLookup);
 
     if (!matchedPrNumber) return line;
 

--- a/src/utils/json-extract.ts
+++ b/src/utils/json-extract.ts
@@ -8,8 +8,12 @@ import { safeJsonParse } from '@/utils/json.js';
  * @throws When no JSON object can be parsed.
  */
 export function extractJsonObject<T = unknown>(rawText: string): T {
+  const directParse = safeJsonParse<T>(rawText);
+  if (directParse !== undefined) {
+    return directParse;
+  }
+
   const strategies: Array<(text: string) => T | undefined> = [
-    tryParseDirect,
     tryParseOutermostSpan,
     tryParseBalancedObject,
   ];
@@ -20,15 +24,6 @@ export function extractJsonObject<T = unknown>(rawText: string): T {
   }
 
   throw new Error('Failed to parse JSON from model output');
-}
-
-/**
- * Attempt to parse the entire string as JSON.
- * @param text Model output to parse.
- * @returns Parsed JSON when the text is valid JSON.
- */
-function tryParseDirect<T>(text: string): T | undefined {
-  return safeJsonParse<T>(text);
 }
 
 /**

--- a/src/utils/markdown-sections.ts
+++ b/src/utils/markdown-sections.ts
@@ -1,0 +1,133 @@
+import {
+  BULLET_PREFIX_RE,
+  H3_SUBHEADER_CAPTURE_RE,
+} from '@/constants/markdown.js';
+
+/** Parsed markdown section headed by an H3 (`###`) line. */
+export type MarkdownSectionBlock = {
+  /** Original heading line including markdown markers. */
+  headingLine: string;
+  /** Heading text without the leading `###`. */
+  name: string;
+  /** Lines that belong to the section body. */
+  lines: string[];
+};
+
+/** Markdown document split into preamble lines and H3 sections. */
+export type MarkdownSectionDocument = {
+  /** Lines before the first H3 section. */
+  preamble: string[];
+  /** Parsed H3 sections in original order. */
+  sections: MarkdownSectionBlock[];
+};
+
+/**
+ * Parse the section name from an H3 markdown heading.
+ * @param line Raw markdown line.
+ * @returns Heading text or `null` when the line is not an H3 heading.
+ */
+export function parseMarkdownSectionName(line: string): string | null {
+  const match = line.match(H3_SUBHEADER_CAPTURE_RE);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Split markdown into leading preamble lines and H3 sections.
+ * WHY: Multiple post-processing steps need the same structural parse, and
+ * sharing it avoids drift between section-moving utilities.
+ * @param markdown Raw markdown document.
+ * @returns Parsed document preserving line order.
+ */
+export function splitMarkdownSections(
+  markdown: string,
+): MarkdownSectionDocument {
+  const lines = markdown.split('\n');
+  const preamble: string[] = [];
+  const sections: MarkdownSectionBlock[] = [];
+  let currentSection: MarkdownSectionBlock | null = null;
+
+  for (const line of lines) {
+    const heading = parseMarkdownSectionName(line);
+    if (heading) {
+      if (currentSection) sections.push(currentSection);
+      currentSection = { headingLine: line, name: heading, lines: [] };
+      continue;
+    }
+
+    if (currentSection) {
+      currentSection.lines.push(line);
+    } else {
+      preamble.push(line);
+    }
+  }
+
+  if (currentSection) sections.push(currentSection);
+  return { preamble, sections };
+}
+
+/**
+ * Check whether section lines contain any non-whitespace content.
+ * @param lines Section body lines.
+ * @returns True when the section contains meaningful content.
+ */
+export function hasMeaningfulMarkdownContent(lines: string[]): boolean {
+  return lines.some((line) => line.trim().length > 0);
+}
+
+/**
+ * Append bullet lines to a section while preserving spacing and avoiding duplicates.
+ * @param section Section to modify in place.
+ * @param bullets Bullet lines to append.
+ */
+export function appendUniqueBulletLines(
+  section: MarkdownSectionBlock,
+  bullets: string[],
+): void {
+  if (!bullets.length) return;
+
+  const existingBullets = new Set(
+    section.lines
+      .filter((line) => BULLET_PREFIX_RE.test(line))
+      .map((line) => line.trim()),
+  );
+  const uniqueBullets = bullets.filter(
+    (line) => !existingBullets.has(line.trim()),
+  );
+  if (!uniqueBullets.length) return;
+
+  if (!hasMeaningfulMarkdownContent(section.lines)) {
+    section.lines = ['', ...uniqueBullets, ''];
+    return;
+  }
+
+  if (!section.lines.length || section.lines[0].trim() !== '') {
+    section.lines.unshift('');
+  }
+
+  let insertIndex = section.lines.length;
+  while (insertIndex > 0 && section.lines[insertIndex - 1].trim() === '') {
+    insertIndex -= 1;
+  }
+  section.lines.splice(insertIndex, 0, ...uniqueBullets);
+
+  if (!section.lines.length || section.lines[section.lines.length - 1].trim()) {
+    section.lines.push('');
+  }
+}
+
+/**
+ * Render a parsed markdown document back to text with normalized blank lines.
+ * @param document Parsed markdown document.
+ * @returns Serialized markdown.
+ */
+export function renderMarkdownSections(
+  document: MarkdownSectionDocument,
+): string {
+  const output: string[] = [];
+  output.push(...document.preamble);
+  for (const section of document.sections) {
+    output.push(section.headingLine);
+    output.push(...section.lines);
+  }
+  return output.join('\n').replace(/\n{3,}/g, '\n\n');
+}

--- a/src/utils/release.ts
+++ b/src/utils/release.ts
@@ -5,12 +5,10 @@ import type {
 } from '@/types/release.js';
 import { ParsedReleaseSchema } from '@/schema/release.js';
 import { SECTION_ORDER } from '@/constants/changelog.js';
-import {
-  stripConventionalPrefix,
-  normalizeTitle,
-} from '@/utils/title-normalize.js';
+import { stripConventionalPrefix } from '@/utils/title-normalize.js';
 import { FULL_CHANGELOG_RE } from '@/constants/release.js';
 import { BULLET_PREFIX_RE } from '@/constants/markdown.js';
+import { buildTitleLookup, findTitleMatch } from '@/utils/title-lookup.js';
 
 const H2_HEADING_RE = /^##\s+(.*)$/;
 const PR_URL_RE = /https?:\/\/\S+\/pull\/(\d+)/; // captures PR number
@@ -301,50 +299,13 @@ export function buildSectionFromRelease(params: {
   sections?: ReleaseSection[];
 }): string {
   const { version, date, items, categories, sections = [] } = params;
-
-  // Normalize titles for fuzzy matching: lowercase, strip conventional prefix,
-  // collapse non-alphanumerics to spaces, and trim.
-  const normalize = (s: string) => normalizeTitle(s);
-
-  // Build both exact and normalized lookup maps.
-  const titleToItem = new Map<string, ReleaseItem>();
-  const normalizedToItem = new Map<string, ReleaseItem>();
-  for (const item of items) {
-    const keys = [item.title, item.rawTitle].filter(Boolean) as string[];
-    // WHY: Avoid redundant insertions when title === rawTitle or keys differ only
-    // by reference; Set preserves lookup flexibility without extra work.
-    const uniqueKeys = new Set(keys);
-    for (const key of uniqueKeys) {
-      titleToItem.set(key, item);
-      titleToItem.set(key.toLowerCase(), item);
-      const norm = normalize(key);
-      normalizedToItem.set(norm, item);
-    }
-  }
-
-  const findItem = (lookupTitle: string): ReleaseItem | undefined => {
-    if (!lookupTitle) return undefined;
-    const direct =
-      titleToItem.get(lookupTitle) ||
-      titleToItem.get(lookupTitle.toLowerCase()) ||
-      titleToItem.get(stripConventionalPrefix(lookupTitle)) ||
-      titleToItem.get(stripConventionalPrefix(lookupTitle).toLowerCase());
-    if (direct) return direct;
-
-    // Fuzzy: try normalized matching with bidirectional prefix check.
-    const normalizedLookup = normalize(lookupTitle);
-    const exact = normalizedToItem.get(normalizedLookup);
-    if (exact) return exact;
-    for (const [k, item] of normalizedToItem) {
-      const minLen = Math.min(k.length, normalizedLookup.length);
-      const maxLen = Math.max(k.length, normalizedLookup.length);
-      // Only match if the shorter string is at least 50% of the longer
-      if (minLen / maxLen < 0.5) continue;
-      if (k.startsWith(normalizedLookup) || normalizedLookup.startsWith(k))
-        return item;
-    }
-    return undefined;
-  };
+  const itemLookup = buildTitleLookup(
+    items.map((item) => ({
+      // WHY: LLM output can refer to either the stripped or raw release-note title.
+      titles: new Set([item.title, item.rawTitle].filter(Boolean) as string[]),
+      value: item,
+    })),
+  );
   const lines: string[] = [`## [v${version}] - ${date}`, ''];
 
   function formatBullet(item: ReleaseItem): string {
@@ -361,7 +322,9 @@ export function buildSectionFromRelease(params: {
     const titles = categories[section] || [];
     const entries: ReleaseItem[] = [];
     for (const candidateTitle of titles) {
-      const item = findItem(candidateTitle);
+      const item = findTitleMatch(candidateTitle, itemLookup, {
+        minRelativePrefixLength: 0.5,
+      });
       if (item) {
         const key = item.pr
           ? `pr-${item.pr}`

--- a/src/utils/remove-merged-prs.ts
+++ b/src/utils/remove-merged-prs.ts
@@ -12,7 +12,7 @@ import {
 export function removeMergedPRs(md: string): string {
   const document = splitMarkdownSections(md);
   document.sections = document.sections.filter(
-    (section) => section.name.toLowerCase() !== 'merged prs',
+    (section) => !section.name.toLowerCase().startsWith('merged prs'),
   );
   return renderMarkdownSections(document);
 }

--- a/src/utils/remove-merged-prs.ts
+++ b/src/utils/remove-merged-prs.ts
@@ -1,3 +1,8 @@
+import {
+  renderMarkdownSections,
+  splitMarkdownSections,
+} from '@/utils/markdown-sections.js';
+
 /**
  * Remove the "Merged PRs" section from a markdown changelog snippet.
  * WHY: This section is noise for our generated changelog; we keep only categorized entries.
@@ -5,29 +10,9 @@
  * @returns Markdown without the "Merged PRs" section and normalized blank lines.
  */
 export function removeMergedPRs(md: string): string {
-  const lines = md.split('\n');
-  const kept: string[] = [];
-  let skippingMergedSection = false;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    if (skippingMergedSection) {
-      if (/^###\s+/.test(trimmed)) {
-        skippingMergedSection = false;
-        // Fall through so the new section header is preserved.
-      } else {
-        continue;
-      }
-    }
-
-    if (/^###\s+Merged PRs/i.test(trimmed)) {
-      skippingMergedSection = true;
-      continue;
-    }
-
-    kept.push(line);
-  }
-
-  return kept.join('\n').replace(/\n{3,}/g, '\n\n');
+  const document = splitMarkdownSections(md);
+  document.sections = document.sections.filter(
+    (section) => section.name.toLowerCase() !== 'merged prs',
+  );
+  return renderMarkdownSections(document);
 }

--- a/src/utils/section-postprocess.ts
+++ b/src/utils/section-postprocess.ts
@@ -7,91 +7,23 @@ import {
   SECTION_CHORE,
   SECTION_ORDER,
 } from '@/constants/changelog.js';
+import { BULLET_PREFIX_RE } from '@/constants/markdown.js';
 import {
-  BULLET_PREFIX_RE,
-  H3_SUBHEADER_CAPTURE_RE,
-} from '@/constants/markdown.js';
+  appendUniqueBulletLines,
+  hasMeaningfulMarkdownContent,
+  renderMarkdownSections,
+  splitMarkdownSections,
+  type MarkdownSectionBlock,
+} from '@/utils/markdown-sections.js';
 
 const SECTION_ORDER_INDEX = new Map(
   SECTION_ORDER.map((sectionName, index) => [sectionName.toLowerCase(), index]),
 );
 
-type SectionBlock = {
-  headingLine: string;
-  name: string;
-  lines: string[];
-};
-
-function parseSectionName(line: string): string | null {
-  const match = line.match(H3_SUBHEADER_CAPTURE_RE);
-  return match ? match[1].trim() : null;
-}
-
-function splitSections(markdown: string): {
-  preamble: string[];
-  sections: SectionBlock[];
-} {
-  const lines = markdown.split('\n');
-  const preamble: string[] = [];
-  const sections: SectionBlock[] = [];
-  let current: SectionBlock | null = null;
-
-  for (const line of lines) {
-    const heading = parseSectionName(line);
-    if (heading) {
-      if (current) sections.push(current);
-      current = { headingLine: line, name: heading, lines: [] };
-      continue;
-    }
-    if (current) {
-      current.lines.push(line);
-    } else {
-      preamble.push(line);
-    }
-  }
-
-  if (current) sections.push(current);
-  return { preamble, sections };
-}
-
-function hasMeaningfulContent(lines: string[]): boolean {
-  return lines.some((line) => line.trim().length > 0);
-}
-
-function appendBulletLines(section: SectionBlock, bullets: string[]): void {
-  if (!bullets.length) return;
-  const existing = new Set(
-    section.lines
-      .filter((line) => BULLET_PREFIX_RE.test(line))
-      .map((line) => line.trim()),
-  );
-  const uniqueBullets = bullets.filter((line) => !existing.has(line.trim()));
-  if (!uniqueBullets.length) return;
-
-  const hasContent = section.lines.some((line) => line.trim().length > 0);
-  if (!hasContent) {
-    section.lines = ['', ...uniqueBullets, ''];
-    return;
-  }
-
-  if (!section.lines.length || section.lines[0].trim() !== '') {
-    section.lines.unshift('');
-  }
-
-  let insertIndex = section.lines.length;
-  while (insertIndex > 0 && section.lines[insertIndex - 1].trim() === '') {
-    insertIndex -= 1;
-  }
-  section.lines.splice(insertIndex, 0, ...uniqueBullets);
-
-  if (!section.lines.length || section.lines[section.lines.length - 1].trim()) {
-    section.lines.push('');
-  }
-}
-
 function moveDependencyUpdatesToChore(markdown: string): string {
   if (!markdown) return markdown;
-  const { preamble, sections } = splitSections(markdown);
+  const document = splitMarkdownSections(markdown);
+  const { sections } = document;
   if (!sections.length) return markdown;
 
   const changedIndex = sections.findIndex(
@@ -119,7 +51,7 @@ function moveDependencyUpdatesToChore(markdown: string): string {
   if (!movedBullets.length) return markdown;
   changedSection.lines = retainedLines;
 
-  if (!hasMeaningfulContent(changedSection.lines)) {
+  if (!hasMeaningfulMarkdownContent(changedSection.lines)) {
     sections.splice(changedIndex, 1);
   }
 
@@ -148,31 +80,24 @@ function moveDependencyUpdatesToChore(markdown: string): string {
     sections.splice(insertIndex, 0, choreSection);
   }
 
-  appendBulletLines(choreSection, movedBullets);
-
-  const output: string[] = [];
-  output.push(...preamble);
-  for (const section of sections) {
-    output.push(section.headingLine);
-    output.push(...section.lines);
-  }
-
-  return output.join('\n').replace(/\n{3,}/g, '\n\n');
+  appendUniqueBulletLines(choreSection, movedBullets);
+  return renderMarkdownSections(document);
 }
 
 function moveBreakingChangesToTop(markdown: string): string {
   if (!markdown) return markdown;
-  const { preamble, sections } = splitSections(markdown);
+  const document = splitMarkdownSections(markdown);
+  const { sections } = document;
   if (!sections.length) return markdown;
 
-  const isBreakingWithContent = (section: SectionBlock) =>
+  const isBreakingWithContent = (section: MarkdownSectionBlock) =>
     section.name.toLowerCase() === SECTION_BREAKING_CHANGES.toLowerCase() &&
-    hasMeaningfulContent(section.lines);
+    hasMeaningfulMarkdownContent(section.lines);
 
   const breakingSections = sections.filter(isBreakingWithContent);
   if (!breakingSections.length) return markdown;
 
-  const mergeBreakingLines = (blocks: SectionBlock[]): string[] => {
+  const mergeBreakingLines = (blocks: MarkdownSectionBlock[]): string[] => {
     const merged: string[] = [];
     for (const block of blocks) {
       if (merged.length) {
@@ -208,22 +133,16 @@ function moveBreakingChangesToTop(markdown: string): string {
   )
     return markdown;
 
-  const mergedBreakingSection: SectionBlock = {
+  const mergedBreakingSection: MarkdownSectionBlock = {
     headingLine: breakingSections[0].headingLine,
     name: SECTION_BREAKING_CHANGES,
     lines: mergeBreakingLines(breakingSections),
   };
-  const otherSections = sections.filter(
-    (section) => !isBreakingWithContent(section),
-  );
-  const output: string[] = [];
-  output.push(...preamble);
-  for (const section of [mergedBreakingSection, ...otherSections]) {
-    output.push(section.headingLine);
-    output.push(...section.lines);
-  }
-
-  return output.join('\n').replace(/\n{3,}/g, '\n\n');
+  document.sections = [
+    mergedBreakingSection,
+    ...sections.filter((section) => !isBreakingWithContent(section)),
+  ];
+  return renderMarkdownSections(document);
 }
 
 /**

--- a/src/utils/title-lookup.ts
+++ b/src/utils/title-lookup.ts
@@ -108,16 +108,21 @@ export function findTitleMatch<Value>(
 ): Value | undefined {
   if (!title) return undefined;
 
+  const normalizedTitle = normalizeTitle(title);
+  if (normalizedTitle) {
+    // WHY: Collision resolution is recorded in the normalized table, so exact
+    // normalized hits must win over direct-key matches to keep lookups stable
+    // across punctuation, casing, and conventional-prefix variants.
+    const exactMatch = lookup.normalized.get(normalizedTitle);
+    if (exactMatch !== undefined) return exactMatch;
+  }
+
   for (const key of buildDirectKeys(title)) {
     const directMatch = lookup.direct.get(key);
     if (directMatch !== undefined) return directMatch;
   }
 
-  const normalizedTitle = normalizeTitle(title);
   if (!normalizedTitle) return undefined;
-
-  const exactMatch = lookup.normalized.get(normalizedTitle);
-  if (exactMatch !== undefined) return exactMatch;
 
   const minRelativePrefixLength = options.minRelativePrefixLength ?? 0;
   for (const [lookupTitle, value] of lookup.normalized) {

--- a/src/utils/title-lookup.ts
+++ b/src/utils/title-lookup.ts
@@ -1,0 +1,137 @@
+import {
+  normalizeTitle,
+  stripConventionalPrefix,
+} from '@/utils/title-normalize.js';
+
+/** Case-insensitive and normalized title lookup tables. */
+export type TitleLookup<Value> = {
+  /** Direct lookup keyed by original, lowercase, and stripped title variants. */
+  direct: Map<string, Value>;
+  /** Normalized lookup used for exact and fuzzy matching. */
+  normalized: Map<string, Value>;
+};
+
+/** Collision context for normalized-title lookups. */
+export type TitleLookupCollision<Value> = {
+  /** Original entry title that produced the collision. */
+  title: string;
+  /** Normalized title key shared by both entries. */
+  normalizedTitle: string;
+  /** Existing value already stored for the normalized key. */
+  existingValue: Value;
+  /** Incoming value competing for the same normalized key. */
+  incomingValue: Value;
+};
+
+type BuildTitleLookupOptions<Value> = {
+  /** Optional resolver for normalized-title collisions. */
+  onNormalizedCollision?: (
+    collision: TitleLookupCollision<Value>,
+  ) => Value | undefined;
+};
+
+type FindTitleMatchOptions = {
+  /** Minimum shared prefix ratio required for fuzzy prefix matching. */
+  minRelativePrefixLength?: number;
+};
+
+function buildDirectKeys(title: string): string[] {
+  const strippedTitle = stripConventionalPrefix(title);
+  return [
+    ...new Set([
+      title,
+      title.toLowerCase(),
+      strippedTitle,
+      strippedTitle.toLowerCase(),
+    ]),
+  ];
+}
+
+/**
+ * Build direct and normalized title lookup tables for later fuzzy matching.
+ * @param entries Title/value pairs to index.
+ * @param options Optional collision policy for normalized keys.
+ * @returns Lookup tables that support exact and fuzzy title resolution.
+ */
+export function buildTitleLookup<Value>(
+  entries: Iterable<{ titles: Iterable<string>; value: Value }>,
+  options: BuildTitleLookupOptions<Value> = {},
+): TitleLookup<Value> {
+  const direct = new Map<string, Value>();
+  const normalized = new Map<string, Value>();
+
+  for (const entry of entries) {
+    for (const title of entry.titles) {
+      if (!title) continue;
+
+      for (const key of buildDirectKeys(title)) {
+        direct.set(key, entry.value);
+      }
+
+      const normalizedTitle = normalizeTitle(title);
+      if (!normalizedTitle) continue;
+
+      const existingValue = normalized.get(normalizedTitle);
+      if (existingValue !== undefined && options.onNormalizedCollision) {
+        const resolvedValue = options.onNormalizedCollision({
+          title,
+          normalizedTitle,
+          existingValue,
+          incomingValue: entry.value,
+        });
+        if (resolvedValue !== undefined) {
+          normalized.set(normalizedTitle, resolvedValue);
+        }
+        continue;
+      }
+
+      if (existingValue === undefined) {
+        normalized.set(normalizedTitle, entry.value);
+      }
+    }
+  }
+
+  return { direct, normalized };
+}
+
+/**
+ * Resolve a title against direct and normalized lookup tables.
+ * @param title Raw title to find.
+ * @param lookup Lookup tables built by `buildTitleLookup`.
+ * @param options Matching options.
+ * @returns Matched value when one is found.
+ */
+export function findTitleMatch<Value>(
+  title: string,
+  lookup: TitleLookup<Value>,
+  options: FindTitleMatchOptions = {},
+): Value | undefined {
+  if (!title) return undefined;
+
+  for (const key of buildDirectKeys(title)) {
+    const directMatch = lookup.direct.get(key);
+    if (directMatch !== undefined) return directMatch;
+  }
+
+  const normalizedTitle = normalizeTitle(title);
+  if (!normalizedTitle) return undefined;
+
+  const exactMatch = lookup.normalized.get(normalizedTitle);
+  if (exactMatch !== undefined) return exactMatch;
+
+  const minRelativePrefixLength = options.minRelativePrefixLength ?? 0;
+  for (const [lookupTitle, value] of lookup.normalized) {
+    const minLength = Math.min(lookupTitle.length, normalizedTitle.length);
+    const maxLength = Math.max(lookupTitle.length, normalizedTitle.length);
+    if (maxLength === 0) continue;
+    if (minLength / maxLength < minRelativePrefixLength) continue;
+    if (
+      normalizedTitle.startsWith(lookupTitle) ||
+      lookupTitle.startsWith(normalizedTitle)
+    ) {
+      return value;
+    }
+  }
+
+  return undefined;
+}

--- a/tests/utils/markdown-sections.test.ts
+++ b/tests/utils/markdown-sections.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  appendUniqueBulletLines,
+  renderMarkdownSections,
+  splitMarkdownSections,
+} from '@/utils/markdown-sections.js';
+
+describe('markdown-sections utils', () => {
+  test('splits and renders H3 sections without changing content', () => {
+    const markdown = [
+      '## [v1.2.3] - 2025-01-01',
+      '',
+      '### Added',
+      '',
+      '- Add feature',
+      '',
+      '### Fixed',
+      '',
+      '- Fix bug',
+      '',
+    ].join('\n');
+
+    const document = splitMarkdownSections(markdown);
+
+    expect(document.preamble).toEqual(['## [v1.2.3] - 2025-01-01', '']);
+    expect(document.sections.map((section) => section.name)).toEqual([
+      'Added',
+      'Fixed',
+    ]);
+    expect(renderMarkdownSections(document)).toBe(markdown);
+  });
+
+  test('appends only unique bullet lines and preserves blank-line framing', () => {
+    const document = splitMarkdownSections(
+      ['### Chore', '', '- Update lockfile', ''].join('\n'),
+    );
+    const [section] = document.sections;
+
+    appendUniqueBulletLines(section, ['- Update lockfile', '- Bump eslint']);
+
+    expect(section.lines).toEqual([
+      '',
+      '- Update lockfile',
+      '- Bump eslint',
+      '',
+    ]);
+  });
+});

--- a/tests/utils/title-lookup.test.ts
+++ b/tests/utils/title-lookup.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from '@jest/globals';
+import { buildTitleLookup, findTitleMatch } from '@/utils/title-lookup.js';
+
+describe('title-lookup utils', () => {
+  test('matches direct titles after stripping conventional prefixes', () => {
+    const lookup = buildTitleLookup([
+      { titles: ['Add login flow'], value: 42 },
+    ]);
+
+    expect(findTitleMatch('feat(auth): Add login flow', lookup)).toBe(42);
+  });
+
+  test('supports fuzzy prefix matching with a relative length threshold', () => {
+    const lookup = buildTitleLookup([
+      { titles: ['Add login flow with passwordless fallback'], value: 42 },
+    ]);
+
+    expect(
+      findTitleMatch('Add login flow with passwordless', lookup, {
+        minRelativePrefixLength: 0.5,
+      }),
+    ).toBe(42);
+    expect(
+      findTitleMatch('Add', lookup, {
+        minRelativePrefixLength: 0.5,
+      }),
+    ).toBeUndefined();
+  });
+
+  test('uses the collision resolver for normalized title clashes', () => {
+    const lookup = buildTitleLookup(
+      [
+        { titles: ['Add login flow'], value: 42 },
+        { titles: ['add-login-flow'], value: 99 },
+      ],
+      {
+        onNormalizedCollision: ({ existingValue, incomingValue }) =>
+          Math.max(existingValue, incomingValue),
+      },
+    );
+
+    expect(findTitleMatch('Add! Login Flow', lookup)).toBe(99);
+  });
+});

--- a/tests/utils/title-lookup.test.ts
+++ b/tests/utils/title-lookup.test.ts
@@ -39,6 +39,7 @@ describe('title-lookup utils', () => {
       },
     );
 
+    expect(findTitleMatch('Add login flow', lookup)).toBe(99);
     expect(findTitleMatch('Add! Login Flow', lookup)).toBe(99);
   });
 });


### PR DESCRIPTION
## Summary

Extract shared markdown and title lookup helpers.

<!-- A brief summary of the changes -->

## Description

Refactor `src/utils` to consolidate repeated markdown-section parsing and title matching logic into shared helpers. 

This extracts reusable markdown-sections and title-lookup utilities, simplifies attach-pr, release, remove-merged-prs, and section-postprocess, and trims the unnecessary `tryParseDirect` wrapper from `json-extract.ts`.

<!-- A detailed explanation of the changes, including why they are needed -->
