### PR TITLE
test: lock changelog refactor behavior

### DIFF
--- a/tests/lib/compute-changelog.test.ts
+++ b/tests/lib/compute-changelog.test.ts
@@ -120,3 +120,38 @@ test('compare link append and unreleased update', () => {
   const compareMatches2 = again.match(/^\[v1\.1\.0\]: .+$/gm) || [];
   expect(compareMatches2.length).toBe(1);
 });
+
+test('preserves header block and exact spacing when anchor is missing', () => {
+  const current = [
+    '# Changelog',
+    '',
+    'Release history for the project.',
+    '',
+    '## [v0.9.0]',
+    '- old',
+    '',
+  ].join('\n');
+
+  const out = computeChangelog(current, {
+    version: '1.0.0',
+    newSection: ['## [v1.0.0]', '', '### Added', '- new'].join('\n'),
+    insertAfterAnchor: 'not-a-heading',
+  });
+
+  expect(out).toBe(
+    [
+      '# Changelog',
+      '',
+      'Release history for the project.',
+      '',
+      '## [v1.0.0]',
+      '',
+      '### Added',
+      '- new',
+      '',
+      '## [v0.9.0]',
+      '- old',
+      '',
+    ].join('\n'),
+  );
+});

--- a/tests/utils/category-score.test.ts
+++ b/tests/utils/category-score.test.ts
@@ -40,4 +40,26 @@ describe('category-score', () => {
     const s = scoreCategories('security: patch CVE-2025-12345');
     expect(bestCategory(s)).toBe('Fixed');
   });
+
+  test('explicit breaking change marker and keywords win over feat prefix', () => {
+    const s = scoreCategories('feat!: breaking change drop support for v1 API');
+    expect(s['Breaking Changes']).toBeGreaterThan(s.Added);
+    expect(bestCategory(s)).toBe('Breaking Changes');
+  });
+
+  test('negative uncertainty signal attenuates strongest main category', () => {
+    const baseline = scoreCategories('fix: prevent crash in parser');
+    const attenuated = scoreCategories(
+      'fix: temporary workaround to prevent crash in parser',
+    );
+
+    expect(attenuated.Fixed).toBeLessThan(baseline.Fixed);
+    expect(bestCategory(attenuated)).toBe('Fixed');
+  });
+
+  test('docs prefix and keyword select Docs', () => {
+    const s = scoreCategories('docs: update README reference');
+    expect(s.Docs).toBeGreaterThan(s.Chore);
+    expect(bestCategory(s)).toBe('Docs');
+  });
 });

--- a/tests/utils/release.test.ts
+++ b/tests/utils/release.test.ts
@@ -74,6 +74,27 @@ describe('release utils', () => {
     );
   });
 
+  test('parseReleaseNotes strips trailing attribution noise after PR and author extraction', () => {
+    const body = [
+      '# v0.2.0',
+      '',
+      "## What's Changed",
+      '- chore: Update docs by @bob by in #77',
+    ].join('\n');
+
+    const parsed = parseReleaseNotes(body, { owner: 'acme', repo: 'repo' });
+
+    expect(parsed.items).toEqual([
+      {
+        title: 'Update docs',
+        rawTitle: 'chore: Update docs',
+        author: 'bob',
+        pr: 77,
+        url: 'https://github.com/acme/repo/pull/77',
+      },
+    ]);
+  });
+
   test('buildSectionFromRelease formats bullets with author and PR link', () => {
     const items = [
       {
@@ -109,6 +130,36 @@ describe('release utils', () => {
     expect(section).toContain('### Release Notes');
     expect(section).toContain(
       'Remember to update configuration files manually.',
+    );
+  });
+
+  test('buildSectionFromRelease matches raw conventional titles and avoids duplicate category membership', () => {
+    const section = buildSectionFromRelease({
+      version: '1.2.3',
+      date: '2026-05-16',
+      items: [
+        {
+          title: 'Add export flag',
+          rawTitle: 'feat: Add export flag',
+          pr: 100,
+          url: 'https://github.com/acme/repo/pull/100',
+        },
+      ],
+      categories: {
+        Added: ['feat: Add export flag'],
+        Changed: ['Add export flag'],
+      },
+    });
+
+    expect(section).toBe(
+      [
+        '## [v1.2.3] - 2026-05-16',
+        '',
+        '### Added',
+        '',
+        '- Add export flag in [#100](https://github.com/acme/repo/pull/100)',
+        '',
+      ].join('\n'),
     );
   });
 });


### PR DESCRIPTION
## Summary

Lock changelog refactor behavior.

<!-- A brief summary of the changes -->

## Description

- Add regression coverage for changelog insertion spacing when the target anchor is missing
- Add release-note parsing/rendering tests for attribution cleanup, raw title matching, and duplicate category prevention
- Add category scoring tests for breaking changes, negative signals, and docs classification

<!-- A detailed explanation of the changes, including why they are needed -->
