### PR TITLE
feat: add changelog generation customization

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -23,6 +23,16 @@ on:
       release_body:
         required: false
         type: string
+      language:
+        required: false
+        type: string
+        default: 'en'
+      instructions:
+        required: false
+        type: string
+      instructions_file:
+        required: false
+        type: string
       minimum_package_age_days:
         required: false
         type: string
@@ -37,6 +47,8 @@ on:
       OPENAI_API_KEY:
         required: false
       ANTHROPIC_API_KEY:
+        required: false
+      GEMINI_API_KEY:
         required: false
 
 jobs:
@@ -58,9 +70,13 @@ jobs:
           release-tag: ${{ inputs.release_tag }}
           release-name: ${{ inputs.release_name }}
           release-body: ${{ inputs.release_body }}
+          language: ${{ inputs.language }}
+          instructions: ${{ inputs.instructions }}
+          instructions-file: ${{ inputs.instructions_file }}
           minimum-package-age-days: ${{ inputs.minimum_package_age_days }}
           dry-run: ${{ inputs.dry_run }}
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -41,16 +41,19 @@ Using it in CI? Jump to [GitHub Actions integration](#github-actions-integration
 
 ### Options
 
-| Option             | Description                                         | Default            |
-| ------------------ | --------------------------------------------------- | ------------------ |
-| `--repo-path`      | Path to repository root                             | `.`                |
-| `--changelog-path` | Path to CHANGELOG file                              | `CHANGELOG.md`     |
-| `--base-branch`    | Base branch for PR                                  | `main`             |
-| `--provider`       | LLM provider (`openai`, `anthropic`, or `gemini`)   | `openai`           |
-| `--release-tag`    | Git ref (tag or HEAD) to generate release for       | latest tag or HEAD |
-| `--release-name`   | Display name for version (without `v`)              | derived from tag   |
-| `--release-body`   | Additional release notes body                       | `""`               |
-| `--dry-run`        | Print updated CHANGELOG to stdout, don’t write file | `false`            |
+| Option                | Description                                         | Default            |
+| --------------------- | --------------------------------------------------- | ------------------ |
+| `--repo-path`         | Path to repository root                             | `.`                |
+| `--changelog-path`    | Path to CHANGELOG file                              | `CHANGELOG.md`     |
+| `--base-branch`       | Base branch for PR                                  | `main`             |
+| `--provider`          | LLM provider (`openai`, `anthropic`, or `gemini`)   | `openai`           |
+| `--release-tag`       | Git ref (tag or HEAD) to generate release for       | latest tag or HEAD |
+| `--release-name`      | Display name for version (without `v`)              | derived from tag   |
+| `--release-body`      | Additional release notes body                       | `""`               |
+| `--language`          | Language for generated changelog prose              | `en`               |
+| `--instructions`      | Additional changelog writing/grouping instructions  | unset              |
+| `--instructions-file` | Path to a file with additional instructions         | unset              |
+| `--dry-run`           | Print updated CHANGELOG to stdout, don’t write file | `false`            |
 
 ## Examples
 
@@ -100,6 +103,20 @@ export OPENAI_MODEL=gpt-4o-mini
 export OPENAI_API_KEY=sk-xxxx
 pnpm dlx @nyaomaru/changelog-bot --release-tag HEAD --release-name 1.0.0 --dry-run
 ```
+
+### Customize generated changelog style
+
+```sh
+pnpm dlx @nyaomaru/changelog-bot \
+  --release-tag HEAD \
+  --release-name 1.0.0 \
+  --language ja \
+  --instructions-file .github/changelog-instructions.md \
+  --dry-run
+```
+
+Custom instructions are additive: the bot still enforces its JSON schema,
+deduplication, and factuality rules.
 
 ### From source (local checkout)
 
@@ -238,6 +255,9 @@ Action inputs (for both 1 and 3):
 - `release-tag` / `release_tag`: tag or ref to generate for.
 - `release-name` / `release_name`: display version (without `v`).
 - `release-body` / `release_body`: extra release notes to merge.
+- `language`: language for generated changelog prose (default `en`).
+- `instructions`: extra changelog writing and grouping instructions.
+- `instructions-file` / `instructions_file`: path to an instructions file, relative to the repository root.
 - `dry-run` / `dry_run`: `'true'` to print without writing/PR.
 
 Outputs: None.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ jobs:
       release_tag: ${{ github.event.release.tag_name }}
       release_name: ${{ github.event.release.tag_name }}
       # release_body: '...'
+      # language: ja
+      # instructions_file: .github/changelog-instructions.md
       # dry_run: 'true'
     secrets:
       REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,16 @@ inputs:
   release-body:
     description: 'Additional release notes body to merge in'
     required: false
+  language:
+    description: 'Language for generated changelog prose'
+    required: false
+    default: 'en'
+  instructions:
+    description: 'Additional changelog writing and grouping instructions'
+    required: false
+  instructions-file:
+    description: 'Path to a file with additional changelog instructions'
+    required: false
   npm-version:
     description: 'npm dist-tag or version range for @nyaomaru/changelog-bot'
     required: false
@@ -67,6 +77,7 @@ runs:
         REPO_FULL_NAME: ${{ github.repository }}
         # Capture release_body safely without inline interpolation issues
         INPUT_RELEASE_BODY: ${{ inputs['release-body'] }}
+        INPUT_INSTRUCTIONS: ${{ inputs.instructions }}
         INPUT_MINIMUM_PACKAGE_AGE_DAYS: ${{ inputs['minimum-package-age-days'] }}
       run: |
         set -euo pipefail
@@ -90,6 +101,7 @@ runs:
           --changelog-path "${{ inputs['changelog-path'] }}"
           --base-branch "${{ inputs['base-branch'] }}"
           --provider "${{ inputs.provider }}"
+          --language "${{ inputs.language }}"
         )
 
         if [ -n "${{ inputs['release-tag'] }}" ]; then
@@ -100,6 +112,12 @@ runs:
         fi
         if [ -n "${INPUT_RELEASE_BODY:-}" ]; then
           CMD+=(--release-body "${INPUT_RELEASE_BODY}")
+        fi
+        if [ -n "${INPUT_INSTRUCTIONS:-}" ]; then
+          CMD+=(--instructions "${INPUT_INSTRUCTIONS}")
+        fi
+        if [ -n "${{ inputs['instructions-file'] }}" ]; then
+          CMD+=(--instructions-file "${{ inputs['instructions-file'] }}")
         fi
         if [ "${{ inputs['dry-run'] }}" = "true" ]; then
           CMD+=(--dry-run)

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,9 @@ runs:
         REPO_FULL_NAME: ${{ github.repository }}
         # Capture release_body safely without inline interpolation issues
         INPUT_RELEASE_BODY: ${{ inputs['release-body'] }}
+        INPUT_LANGUAGE: ${{ inputs.language }}
         INPUT_INSTRUCTIONS: ${{ inputs.instructions }}
+        INPUT_INSTRUCTIONS_FILE: ${{ inputs['instructions-file'] }}
         INPUT_MINIMUM_PACKAGE_AGE_DAYS: ${{ inputs['minimum-package-age-days'] }}
       run: |
         set -euo pipefail
@@ -101,7 +103,7 @@ runs:
           --changelog-path "${{ inputs['changelog-path'] }}"
           --base-branch "${{ inputs['base-branch'] }}"
           --provider "${{ inputs.provider }}"
-          --language "${{ inputs.language }}"
+          --language "${INPUT_LANGUAGE}"
         )
 
         if [ -n "${{ inputs['release-tag'] }}" ]; then
@@ -116,8 +118,8 @@ runs:
         if [ -n "${INPUT_INSTRUCTIONS:-}" ]; then
           CMD+=(--instructions "${INPUT_INSTRUCTIONS}")
         fi
-        if [ -n "${{ inputs['instructions-file'] }}" ]; then
-          CMD+=(--instructions-file "${{ inputs['instructions-file'] }}")
+        if [ -n "${INPUT_INSTRUCTIONS_FILE:-}" ]; then
+          CMD+=(--instructions-file "${INPUT_INSTRUCTIONS_FILE}")
         fi
         if [ "${{ inputs['dry-run'] }}" = "true" ]; then
           CMD+=(--dry-run)

--- a/src/constants/system-prompts.ts
+++ b/src/constants/system-prompts.ts
@@ -17,6 +17,8 @@ Output MUST be a SINGLE JSON object (no prose) matching the schema keys:
 
 Rules:
 - Do not hallucinate items. Use only given commits/PRs or releaseBody.
+- Follow customInstructions when present, unless they conflict with this schema or factuality rules.
+- Write generated changelog prose in the requested language.
 - Merge duplicates; group related changes under the same subsection.
 - Prefer user-facing impact; relegate internal chores to "Chore".
 - Keep bullets short (≤ 88 chars) and consistent.

--- a/src/lib/changelog-run.ts
+++ b/src/lib/changelog-run.ts
@@ -13,6 +13,7 @@ import {
   resolveRunCredentials,
 } from '@/lib/release-context.js';
 import { finalizeChangelogUpdate } from '@/lib/changelog-update.js';
+import { resolveCustomInstructions } from '@/lib/customization.js';
 import { formatDryRunDiagnostics } from '@/utils/dry-run-diagnostics.js';
 import {
   DEFAULT_PR_LABELS,
@@ -46,6 +47,8 @@ export type ChangelogRunDependencies = {
   mapCommitsToPrs: typeof mapCommitsToPrs;
   /** Fetch GitHub release notes when not passed by CLI. */
   fetchReleaseBody: typeof fetchReleaseBody;
+  /** Resolve inline and file-based changelog customization instructions. */
+  resolveCustomInstructions: typeof resolveCustomInstructions;
   /** Build commit SHA -> PR number mappings. */
   buildPrMapBySha: typeof buildPrMapBySha;
   /** Build normalized title -> PR number mappings. */
@@ -74,6 +77,7 @@ const defaultDependencies: ChangelogRunDependencies = {
   resolveRunCredentials,
   mapCommitsToPrs,
   fetchReleaseBody,
+  resolveCustomInstructions,
   buildPrMapBySha,
   buildTitleToPr,
   getProviderRuntimeConfig,
@@ -151,6 +155,11 @@ export async function executeChangelogRun(params: {
     apiPrMap,
   });
   const titleToPr = deps.buildTitleToPr(commitList, prs, prMapBySha);
+  const customInstructions = deps.resolveCustomInstructions({
+    instructions: cli.instructions,
+    instructionsFile: cli.instructionsFile,
+    repoPath,
+  });
   const providerConfig = deps.getProviderRuntimeConfig(
     appConfig,
     provider.name,
@@ -163,6 +172,8 @@ export async function executeChangelogRun(params: {
     releaseRef,
     prevRef,
     releaseBody,
+    language: cli.language,
+    customInstructions,
     existingChangelog: existing,
     commitList,
     prs,

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -32,6 +32,9 @@ export async function parseCliArgs(argv: string[]): Promise<CliOptions> {
     .option('release-tag', { type: 'string' })
     .option('release-name', { type: 'string' })
     .option('release-body', { type: 'string', default: '' })
+    .option('language', { type: 'string', default: 'en' })
+    .option('instructions', { type: 'string' })
+    .option('instructions-file', { type: 'string' })
     .option('dry-run', { type: 'boolean', default: false })
     .strict()
     .parse();
@@ -44,6 +47,9 @@ export async function parseCliArgs(argv: string[]): Promise<CliOptions> {
     releaseTag: parsed['release-tag'],
     releaseName: parsed['release-name'],
     releaseBody: parsed['release-body'],
+    language: parsed.language,
+    instructions: parsed.instructions,
+    instructionsFile: parsed['instructions-file'],
     dryRun: parsed['dry-run'],
   });
 }

--- a/src/lib/customization.ts
+++ b/src/lib/customization.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+
+const CUSTOM_INSTRUCTIONS_ENCODING = 'utf8';
+
+/** Inputs used to resolve optional changelog customization instructions. */
+export type ResolveCustomInstructionsInput = {
+  /** Inline instructions passed through the CLI or Action input. */
+  instructions?: string;
+  /** Path to an instructions file, relative to repoPath unless absolute. */
+  instructionsFile?: string;
+  /** Repository root used to resolve relative instruction file paths. */
+  repoPath: string;
+};
+
+function normalizeInstructionText(text?: string): string | undefined {
+  const trimmedText = text?.trim();
+  return trimmedText ? trimmedText : undefined;
+}
+
+function readInstructionsFile(
+  repoPath: string,
+  instructionsFile: string,
+): string {
+  const resolvedPath = isAbsolute(instructionsFile)
+    ? instructionsFile
+    : join(repoPath, instructionsFile);
+  return readFileSync(resolvedPath, CUSTOM_INSTRUCTIONS_ENCODING);
+}
+
+/**
+ * Resolve inline and file-based customization instructions into one prompt block.
+ * @param input Inline instructions, optional file path, and repository path.
+ * @returns Combined instructions, or undefined when none were provided.
+ */
+export function resolveCustomInstructions(
+  input: ResolveCustomInstructionsInput,
+): string | undefined {
+  const instructionParts = [
+    normalizeInstructionText(input.instructions),
+    input.instructionsFile
+      ? normalizeInstructionText(
+          readInstructionsFile(input.repoPath, input.instructionsFile),
+        )
+      : undefined,
+  ].filter((instructionPart): instructionPart is string =>
+    Boolean(instructionPart),
+  );
+
+  return instructionParts.length ? instructionParts.join('\n\n') : undefined;
+}

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -30,5 +30,6 @@ export function buildLLMInput(input: BuildLLMInput): LLMInput {
     mergedPRs: input.mergedPRs,
     changelogPreview,
     language: input.language,
+    customInstructions: input.customInstructions,
   };
 }

--- a/src/schema/cli.ts
+++ b/src/schema/cli.ts
@@ -17,6 +17,9 @@ export const CliOptionsSchema = z.object({
   releaseTag: z.string().optional(),
   releaseName: z.string().optional(),
   releaseBody: z.string().default(''),
+  language: z.string().min(1).default('en'),
+  instructions: z.string().optional(),
+  instructionsFile: z.string().optional(),
   dryRun: z.boolean().default(false),
 });
 

--- a/src/types/changelog-output.ts
+++ b/src/types/changelog-output.ts
@@ -25,6 +25,10 @@ export type BuildChangelogLlmOutputParams = {
   prevRef: string;
   /** Release notes body fetched from GitHub or provided by CLI. */
   releaseBody: string;
+  /** Output language requested for generated changelog text. */
+  language: string;
+  /** Optional user-provided writing and grouping guidance. */
+  customInstructions?: string;
   /** Existing changelog content before the update. */
   existingChangelog: string;
   /** Commits included in the current release range. */

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -21,8 +21,10 @@ export type LLMInput = {
   mergedPRs: string;
   /** Truncated snapshot of the existing changelog. */
   changelogPreview: string;
-  /** Output language; currently fixed to English. */
-  language: 'en';
+  /** Output language requested for generated changelog text. */
+  language: string;
+  /** Optional user-provided writing and grouping guidance. */
+  customInstructions?: string;
 };
 
 /** Structured output expected from provider responses. */

--- a/src/utils/llm-output-model.ts
+++ b/src/utils/llm-output-model.ts
@@ -46,6 +46,8 @@ export async function buildOutputFromModelOrFallback(
     prevRef,
     releaseRef,
     releaseBody,
+    language,
+    customInstructions,
     existingChangelog,
     commitList,
     prs,
@@ -66,7 +68,8 @@ export async function buildOutputFromModelOrFallback(
     gitLog: logsForLLM,
     mergedPRs: prs,
     changelog: existingChangelog,
-    language: 'en',
+    language,
+    customInstructions,
   });
 
   let aiUsed = false;

--- a/src/utils/llm-output.ts
+++ b/src/utils/llm-output.ts
@@ -15,11 +15,17 @@ export async function buildChangelogLlmOutput(
   params: BuildChangelogLlmOutputParams,
 ): Promise<BuildLlmOutputResult> {
   const fallbackReasons: string[] = [];
-  const fromRelease = await buildOutputFromReleaseNotes(
-    params,
-    fallbackReasons,
+  const hasCustomization = Boolean(
+    params.customInstructions || params.language !== 'en',
   );
-  if (fromRelease) return fromRelease;
+
+  if (!hasCustomization) {
+    const fromRelease = await buildOutputFromReleaseNotes(
+      params,
+      fallbackReasons,
+    );
+    if (fromRelease) return fromRelease;
+  }
 
   return buildOutputFromModelOrFallback(params, fallbackReasons);
 }

--- a/src/utils/llm-output.ts
+++ b/src/utils/llm-output.ts
@@ -19,7 +19,7 @@ export async function buildChangelogLlmOutput(
     params.customInstructions || params.language !== 'en',
   );
 
-  if (!hasCustomization) {
+  if (!hasCustomization || !params.hasProviderKey) {
     const fromRelease = await buildOutputFromReleaseNotes(
       params,
       fallbackReasons,

--- a/tests/lib/changelog-run.test.ts
+++ b/tests/lib/changelog-run.test.ts
@@ -11,6 +11,9 @@ const cli = {
   releaseTag: 'v1.2.3',
   releaseName: '1.2.3',
   releaseBody: 'release notes from cli',
+  language: 'ja',
+  instructions: 'Use concise bullets.',
+  instructionsFile: '.github/changelog-instructions.md',
   dryRun: true,
 };
 
@@ -66,6 +69,7 @@ describe('executeChangelogRun', () => {
       })),
       mapCommitsToPrs: jest.fn(),
       fetchReleaseBody: jest.fn(),
+      resolveCustomInstructions: jest.fn(() => 'combined instructions'),
       buildPrMapBySha: jest.fn(() => ({ abcdef1234567890: [123] })),
       buildTitleToPr: jest.fn(() => ({ 'add CLI dry run': 123 })),
       getProviderRuntimeConfig: jest.fn(() => appConfig.providers.openai),
@@ -104,6 +108,8 @@ describe('executeChangelogRun', () => {
     expect(deps.buildChangelogLlmOutput).toHaveBeenCalledWith(
       expect.objectContaining({
         releaseBody: 'release notes from cli',
+        language: 'ja',
+        customInstructions: 'combined instructions',
         prs: 'merged prs',
         existingChangelog: 'existing changelog',
         provider,

--- a/tests/lib/cli-args.test.ts
+++ b/tests/lib/cli-args.test.ts
@@ -23,6 +23,9 @@ describe('cli-args', () => {
     expect(out.releaseTag).toBeUndefined();
     expect(out.releaseName).toBeUndefined();
     expect(out.releaseBody).toBe('');
+    expect(out.language).toBe('en');
+    expect(out.instructions).toBeUndefined();
+    expect(out.instructionsFile).toBeUndefined();
     expect(out.dryRun).toBe(false);
   });
 
@@ -44,6 +47,12 @@ describe('cli-args', () => {
       '1.2.3',
       '--release-body',
       'notes',
+      '--language',
+      'ja',
+      '--instructions',
+      'Use concise bullets.',
+      '--instructions-file',
+      '.github/changelog-instructions.md',
       '--dry-run',
     ]);
 
@@ -54,6 +63,9 @@ describe('cli-args', () => {
     expect(out.releaseTag).toBe('v1.2.3');
     expect(out.releaseName).toBe('1.2.3');
     expect(out.releaseBody).toBe('notes');
+    expect(out.language).toBe('ja');
+    expect(out.instructions).toBe('Use concise bullets.');
+    expect(out.instructionsFile).toBe('.github/changelog-instructions.md');
     expect(out.dryRun).toBe(true);
   });
 

--- a/tests/lib/customization.test.ts
+++ b/tests/lib/customization.test.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, test } from '@jest/globals';
+import { resolveCustomInstructions } from '@/lib/customization.js';
+
+describe('resolveCustomInstructions', () => {
+  test('combines inline and file instructions', () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'changelog-bot-'));
+    try {
+      writeFileSync(
+        join(repoPath, 'instructions.md'),
+        'Group dependency updates under Chore.\n',
+        'utf8',
+      );
+
+      expect(
+        resolveCustomInstructions({
+          instructions: 'Write in Japanese.',
+          instructionsFile: 'instructions.md',
+          repoPath,
+        }),
+      ).toBe('Write in Japanese.\n\nGroup dependency updates under Chore.');
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  test('returns undefined when no instructions are provided', () => {
+    expect(resolveCustomInstructions({ repoPath: '.' })).toBeUndefined();
+  });
+});

--- a/tests/lib/prompt-build-llm-input.test.ts
+++ b/tests/lib/prompt-build-llm-input.test.ts
@@ -16,7 +16,8 @@ test('buildLLMInput truncates changelog to preview limit and maps fields', () =>
     gitLog: 'abc Fix: something',
     mergedPRs: '- #123 Some PR',
     changelog: longChangelog,
-    language: 'en',
+    language: 'ja',
+    customInstructions: 'Write concise user-facing bullets.',
   });
 
   expect(input.repo).toBe('owner/repo');
@@ -27,6 +28,7 @@ test('buildLLMInput truncates changelog to preview limit and maps fields', () =>
   expect(input.releaseBody).toBe('release body');
   expect(input.gitLog).toBe('abc Fix: something');
   expect(input.mergedPRs).toBe('- #123 Some PR');
-  expect(input.language).toBe('en');
+  expect(input.language).toBe('ja');
+  expect(input.customInstructions).toBe('Write concise user-facing bullets.');
   expect(input.changelogPreview.length).toBe(CHANGELOG_PREVIEW_LIMIT);
 });

--- a/tests/utils/llm-output.test.ts
+++ b/tests/utils/llm-output.test.ts
@@ -28,27 +28,37 @@ const mockProviderConfig = {
   model: 'mock-model',
 };
 
+function buildBaseParams(overrides = {}) {
+  return {
+    owner: 'octo',
+    repo: 'repo',
+    version: '1.0.0',
+    date: '2024-01-01',
+    releaseRef: 'v1.0.0',
+    prevRef: 'v0.9.0',
+    releaseBody: '',
+    language: 'en',
+    existingChangelog: '',
+    commitList: [],
+    prs: '',
+    prMapBySha: {},
+    titleToPr: {},
+    provider: mockProvider,
+    providerConfig: mockProviderConfig,
+    hasProviderKey: false,
+    token: undefined,
+    githubApiBase: 'https://api.github.com',
+    ...overrides,
+  };
+}
+
 describe('llm-output', () => {
   test('falls back when no provider key and no release notes', async () => {
-    const result = await buildChangelogLlmOutput({
-      owner: 'octo',
-      repo: 'repo',
-      version: '1.0.0',
-      date: '2024-01-01',
-      releaseRef: 'v1.0.0',
-      prevRef: 'v0.9.0',
-      releaseBody: '',
-      existingChangelog: '',
-      commitList: [{ sha: 'abcdef1', subject: 'feat: add feature' }],
-      prs: '',
-      prMapBySha: {},
-      titleToPr: {},
-      provider: mockProvider,
-      providerConfig: mockProviderConfig,
-      hasProviderKey: false,
-      token: undefined,
-      githubApiBase: 'https://api.github.com',
-    });
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        commitList: [{ sha: 'abcdef1', subject: 'feat: add feature' }],
+      }),
+    );
 
     expect(result.fallbackReasons).toContain(
       'Missing API key for provider: openai',
@@ -63,25 +73,11 @@ describe('llm-output', () => {
   });
 
   test('builds output from release notes without a provider key', async () => {
-    const result = await buildChangelogLlmOutput({
-      owner: 'octo',
-      repo: 'repo',
-      version: '1.0.0',
-      date: '2024-01-01',
-      releaseRef: 'v1.0.0',
-      prevRef: 'v0.9.0',
-      releaseBody: "## What's Changed\n- Add feature\n",
-      existingChangelog: '',
-      commitList: [],
-      prs: '',
-      prMapBySha: {},
-      titleToPr: {},
-      provider: mockProvider,
-      providerConfig: mockProviderConfig,
-      hasProviderKey: false,
-      token: undefined,
-      githubApiBase: 'https://api.github.com',
-    });
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: "## What's Changed\n- Add feature\n",
+      }),
+    );
 
     expect(result.fallbackReasons).toContain(
       'Used GitHub Release Notes as the source (no model call)',
@@ -96,30 +92,16 @@ describe('llm-output', () => {
 
   test('preserves custom release-note sections when no items are parsed', async () => {
     const whatsNewHeading = 'What\u2019s New \u{1F680}';
-    const result = await buildChangelogLlmOutput({
-      owner: 'octo',
-      repo: 'repo',
-      version: '1.0.0',
-      date: '2024-01-01',
-      releaseRef: 'v1.0.0',
-      prevRef: 'v0.9.0',
-      releaseBody: [
-        `## ${whatsNewHeading}`,
-        'Introduces the `assert` helper and usage examples.',
-        '',
-        '**Full Changelog**: v0.9.0...v1.0.0',
-      ].join('\n'),
-      existingChangelog: '',
-      commitList: [],
-      prs: '',
-      prMapBySha: {},
-      titleToPr: {},
-      provider: mockProvider,
-      providerConfig: mockProviderConfig,
-      hasProviderKey: false,
-      token: undefined,
-      githubApiBase: 'https://api.github.com',
-    });
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: [
+          `## ${whatsNewHeading}`,
+          'Introduces the `assert` helper and usage examples.',
+          '',
+          '**Full Changelog**: v0.9.0...v1.0.0',
+        ].join('\n'),
+      }),
+    );
 
     expect(result.fallbackReasons).toContain(
       'Used GitHub Release Notes as the source (no model call)',
@@ -137,33 +119,53 @@ describe('llm-output', () => {
   });
 
   test('keeps fallback note when provider key exists but release notes have no items', async () => {
-    const result = await buildChangelogLlmOutput({
-      owner: 'octo',
-      repo: 'repo',
-      version: '1.0.0',
-      date: '2024-01-01',
-      releaseRef: 'v1.0.0',
-      prevRef: 'v0.9.0',
-      releaseBody: [
-        '## What\u2019s New',
-        'User-facing highlights only.',
-        '',
-        '**Full Changelog**: v0.9.0...v1.0.0',
-      ].join('\n'),
-      existingChangelog: '',
-      commitList: [],
-      prs: '',
-      prMapBySha: {},
-      titleToPr: {},
-      provider: mockProvider,
-      providerConfig: mockProviderConfig,
-      hasProviderKey: true,
-      token: undefined,
-      githubApiBase: 'https://api.github.com',
-    });
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: [
+          '## What\u2019s New',
+          'User-facing highlights only.',
+          '',
+          '**Full Changelog**: v0.9.0...v1.0.0',
+        ].join('\n'),
+        hasProviderKey: true,
+      }),
+    );
 
     expect(result.aiUsed).toBe(false);
     expect(result.llm.pr_body).toContain('Generated without LLM');
     expect(result.llm.new_section_markdown).toContain('### What\u2019s New');
+  });
+
+  test('uses model path when custom instructions are set with release notes', async () => {
+    const generate = jest.fn(async (input) => ({
+      new_section_markdown: `## [v${input.version}] - ${input.date}\n### Added\n- Customized output`,
+      insert_after_anchor: '## [Unreleased]',
+      pr_title: `docs(changelog): ${input.version}`,
+      pr_body: 'Customized changelog.',
+      labels: ['changelog'],
+    }));
+    const providerWithModel = { ...mockProvider, generate };
+
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: "## What's Changed\n- Add feature\n",
+        customInstructions: 'Write in Japanese.',
+        provider: providerWithModel,
+        providerConfig: { apiKey: 'sk-test', model: 'mock-model' },
+        hasProviderKey: true,
+      }),
+    );
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        releaseBody: "## What's Changed\n- Add feature\n",
+        customInstructions: 'Write in Japanese.',
+      }),
+    );
+    expect(result.aiUsed).toBe(true);
+    expect(result.fallbackReasons).not.toContain(
+      'Used GitHub Release Notes as the source (no model call)',
+    );
+    expect(result.llm.new_section_markdown).toContain('Customized output');
   });
 });

--- a/tests/utils/llm-output.test.ts
+++ b/tests/utils/llm-output.test.ts
@@ -168,4 +168,37 @@ describe('llm-output', () => {
     );
     expect(result.llm.new_section_markdown).toContain('Customized output');
   });
+
+  test('uses model path when non-default language is set with release notes', async () => {
+    const generate = jest.fn(async (input) => ({
+      new_section_markdown: `## [v${input.version}] - ${input.date}\n### Added\n- 日本語の出力`,
+      insert_after_anchor: '## [Unreleased]',
+      pr_title: `docs(changelog): ${input.version}`,
+      pr_body: 'Localized changelog.',
+      labels: ['changelog'],
+    }));
+    const providerWithModel = { ...mockProvider, generate };
+
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: "## What's Changed\n- Add feature\n",
+        language: 'ja',
+        provider: providerWithModel,
+        providerConfig: { apiKey: 'sk-test', model: 'mock-model' },
+        hasProviderKey: true,
+      }),
+    );
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        releaseBody: "## What's Changed\n- Add feature\n",
+        language: 'ja',
+      }),
+    );
+    expect(result.aiUsed).toBe(true);
+    expect(result.fallbackReasons).not.toContain(
+      'Used GitHub Release Notes as the source (no model call)',
+    );
+    expect(result.llm.new_section_markdown).toContain('日本語の出力');
+  });
 });


### PR DESCRIPTION
## Summary

Add changelog generation customization.

<!-- A brief summary of the changes -->

## Description

- add changelog customization options: `--language`, `--instructions`, and `--instructions-file`
- pass custom instructions into LLM input while keeping schema, deduplication, and factuality rules enforced
- expose matching GitHub Action inputs and document customization usage
- add tests for CLI parsing, instruction resolution, and prompt input mapping

<!-- A detailed explanation of the changes, including why they are needed -->
