### PR TITLE
chore: update pnpm to 11.2.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We welcome improvements of all kinds: features, fixes, tests, docs, and refactor
 Using mise (recommended):
 
 ```sh
-mise install         # installs Node 22 and pnpm 10.12
+mise install         # installs Node 22 and pnpm 11.2.2
 mise dev_install     # installs dependencies
 ```
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -4,12 +4,12 @@ Welcome! This is the developer guide for changelog-bot. It keeps things practica
 
 ## Quick Start
 
-- Requirements: Node 22, pnpm 10.12
+- Requirements: Node 22, pnpm 11.2.2
 - Recommended: use mise to pin tools and run tasks
 
 ```sh
 # Clone and install
-mise install              # installs Node 22 and pnpm 10.12
+mise install              # installs Node 22 and pnpm 11.2.2
 mise dev_install          # installs dependencies
 
 # Build and try the CLI

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ If you're contributing to `changelog-bot`, the repo ships a `mise.toml` to pin t
 
 ### Mise (toolchain & tasks)
 
-- Tools: Node `22`, pnpm `10.12`.
+- Tools: Node `22`, pnpm `11.2.2`.
 - Tasks: `lint`, `build`, `test`, `test_unit`, `test_performance`, `qa`.
 
 ```sh

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
       run: |
         set -euo pipefail
         corepack enable
-        corepack prepare pnpm@10.12.0 --activate
+        corepack prepare pnpm@11.2.2 --activate
 
     - name: Run changelog-bot
       shell: bash

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "22"
-pnpm = "11.2.2"
+"npm:pnpm" = "11.2.2"
 
 [tasks.start]
 run = "pnpm start"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "22"
-pnpm = "10.12"
+pnpm = "11.2.2"
 
 [tasks.start]
 run = "pnpm start"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# WHY: Delay installs of newly published packages for 48 hours to reduce
+# exposure to compromised releases before the ecosystem has time to react.
+minimumReleaseAge: 2880
+
+allowBuilds:
+  esbuild: false
+  lefthook: false
+  unrs-resolver: false


### PR DESCRIPTION
## Summary

Update pnpm to v11.2.2.

<!-- A brief summary of the changes -->

## Description

- Update pnpm from v10.12 to v11.2.2
- Switch mise pnpm declaration to "npm:pnpm" = "11.2.2"

<!-- A detailed explanation of the changes, including why they are needed -->
