### PR TITLE
fix: CLI version difference

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -36,7 +36,7 @@ on:
       minimum_package_age_days:
         required: false
         type: string
-        default: '2'
+        default: '0'
       dry_run:
         required: false
         type: string

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
   minimum-package-age-days:
     description: 'Minimum age in days required for the npm package version resolved from npm-version'
     required: false
-    default: '2'
+    default: '0'
   dry-run:
     description: "If 'true', print updated changelog without writing or PR"
     required: false


### PR DESCRIPTION
## Summary

Fix CLI version difference.

<!-- A brief summary of the changes -->

## Description

Fix `minimum-package-age-days` default value is 0 because it causes the version difference between action.yml and released package.

<!-- A detailed explanation of the changes, including why they are needed -->
