### PR TITLE
feat: add config file support

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -6,6 +6,9 @@ on:
       changelog_path:
         required: true
         type: string
+      config_path:
+        required: false
+        type: string
       base_branch:
         required: false
         type: string
@@ -65,6 +68,7 @@ jobs:
         uses: nyaomaru/changelog-bot@v0
         with:
           changelog-path: ${{ inputs.changelog_path }}
+          config-path: ${{ inputs.config_path }}
           base-branch: ${{ inputs.base_branch }}
           provider: ${{ inputs.provider }}
           release-tag: ${{ inputs.release_tag }}

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -42,7 +42,6 @@ on:
       dry_run:
         required: false
         type: string
-        default: 'false'
     secrets:
       REPO_TOKEN:
         required: true

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -3,8 +3,10 @@ name: Shared Changelog Workflow
 on:
   workflow_call:
     inputs:
+      # WHY: Keep CLI-backed defaults in the CLI/action. Workflow-call defaults
+      # would be forwarded as explicit values and override config-file settings.
       changelog_path:
-        required: true
+        required: false
         type: string
       config_path:
         required: false
@@ -12,11 +14,9 @@ on:
       base_branch:
         required: false
         type: string
-        default: 'main'
       provider:
         required: false
         type: string
-        default: 'openai'
       release_tag:
         required: false
         type: string
@@ -29,7 +29,6 @@ on:
       language:
         required: false
         type: string
-        default: 'en'
       instructions:
         required: false
         type: string

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Action inputs (for both 1 and 3):
 - `language`: language for generated changelog prose (default `en`).
 - `instructions`: extra changelog writing and grouping instructions.
 - `instructions-file` / `instructions_file`: path to an instructions file, relative to the repository root.
-- `dry-run` / `dry_run`: `'true'` to print without writing/PR.
+- `dry-run` / `dry_run`: `'true'` to print without writing/PR; explicitly set `'false'` to override `dryRun: true` from config.
 
 When `config-path` is used, omitted action inputs can be supplied by the config file. Inputs that are explicitly set in workflow YAML are forwarded as CLI flags and take precedence over config values, even when the value matches the documented default.
 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,20 @@ Using it in CI? Jump to [GitHub Actions integration](#github-actions-integration
 
 ### Options
 
-| Option                | Description                                         | Default            |
-| --------------------- | --------------------------------------------------- | ------------------ |
-| `--repo-path`         | Path to repository root                             | `.`                |
-| `--changelog-path`    | Path to CHANGELOG file                              | `CHANGELOG.md`     |
-| `--base-branch`       | Base branch for PR                                  | `main`             |
-| `--provider`          | LLM provider (`openai`, `anthropic`, or `gemini`)   | `openai`           |
-| `--release-tag`       | Git ref (tag or HEAD) to generate release for       | latest tag or HEAD |
-| `--release-name`      | Display name for version (without `v`)              | derived from tag   |
-| `--release-body`      | Additional release notes body                       | `""`               |
-| `--language`          | Language for generated changelog prose              | `en`               |
-| `--instructions`      | Additional changelog writing/grouping instructions  | unset              |
-| `--instructions-file` | Path to a file with additional instructions         | unset              |
-| `--dry-run`           | Print updated CHANGELOG to stdout, don’t write file | `false`            |
+| Option                | Description                                         | Default                                |
+| --------------------- | --------------------------------------------------- | -------------------------------------- |
+| `--repo-path`         | Path to repository root                             | `.`                                    |
+| `--config`            | Path to JSON config file                            | `changelog-bot.config.json` if present |
+| `--changelog-path`    | Path to CHANGELOG file                              | `CHANGELOG.md`                         |
+| `--base-branch`       | Base branch for PR                                  | `main`                                 |
+| `--provider`          | LLM provider (`openai`, `anthropic`, or `gemini`)   | `openai`                               |
+| `--release-tag`       | Git ref (tag or HEAD) to generate release for       | latest tag or HEAD                     |
+| `--release-name`      | Display name for version (without `v`)              | derived from tag                       |
+| `--release-body`      | Additional release notes body                       | `""`                                   |
+| `--language`          | Language for generated changelog prose              | `en`                                   |
+| `--instructions`      | Additional changelog writing/grouping instructions  | unset                                  |
+| `--instructions-file` | Path to a file with additional instructions         | unset                                  |
+| `--dry-run`           | Print updated CHANGELOG to stdout, don’t write file | `false`                                |
 
 ## Examples
 
@@ -117,6 +118,35 @@ pnpm dlx @nyaomaru/changelog-bot \
 
 Custom instructions are additive: the bot still enforces its JSON schema,
 deduplication, and factuality rules.
+
+### Use a config file
+
+Create `changelog-bot.config.json` in the directory where you run the CLI:
+
+```json
+{
+  "provider": "gemini",
+  "language": "nl",
+  "instructionsFile": ".github/changelog-instructions.md"
+}
+```
+
+Then run normally:
+
+```sh
+pnpm dlx @nyaomaru/changelog-bot --release-tag HEAD --release-name 1.0.0
+```
+
+CLI flags override config file values. To use a different file:
+
+```sh
+pnpm dlx @nyaomaru/changelog-bot --config .github/changelog-bot.json --dry-run
+```
+
+Config files use camelCase keys matching the CLI options:
+`repoPath`, `changelogPath`, `baseBranch`, `provider`, `releaseTag`,
+`releaseName`, `releaseBody`, `language`, `instructions`,
+`instructionsFile`, and `dryRun`. Unknown keys are rejected so typos fail fast.
 
 ### From source (local checkout)
 
@@ -232,6 +262,7 @@ jobs:
     uses: nyaomaru/changelog-bot/.github/workflows/changelog.yaml@main
     with:
       changelog_path: CHANGELOG.md
+      # config_path: .github/changelog-bot.json
       base_branch: main
       provider: openai
       release_tag: ${{ github.event.release.tag_name }}
@@ -250,6 +281,7 @@ jobs:
 Action inputs (for both 1 and 3):
 
 - `changelog-path` / `changelog_path`: path to `CHANGELOG.md` (default `CHANGELOG.md`).
+- `config-path` / `config_path`: path to a JSON config file.
 - `base-branch` / `base_branch`: base branch for PR (default `main`).
 - `provider`: `openai`, `anthropic`, or `gemini` (default `openai`).
 - `npm-version` / `npm_version`: npm dist-tag or range for the CLI package (default `latest`).

--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ Action inputs (for both 1 and 3):
 - `instructions-file` / `instructions_file`: path to an instructions file, relative to the repository root.
 - `dry-run` / `dry_run`: `'true'` to print without writing/PR.
 
+When `config-path` is used, omitted action inputs can be supplied by the config file. Inputs that are explicitly set in workflow YAML are forwarded as CLI flags and take precedence over config values, even when the value matches the documented default.
+
 Outputs: None.
 
 Security note:

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
     description: 'Path to CHANGELOG file'
     required: false
     default: 'CHANGELOG.md'
+  config-path:
+    description: 'Path to changelog-bot JSON config file'
+    required: false
   base-branch:
     description: 'Base branch for the PR'
     required: false
@@ -76,11 +79,19 @@ runs:
         # Allow repo name to be auto-detected by the CLI
         REPO_FULL_NAME: ${{ github.repository }}
         # Capture release_body safely without inline interpolation issues
+        INPUT_CONFIG_PATH: ${{ inputs['config-path'] }}
+        INPUT_CHANGELOG_PATH: ${{ inputs['changelog-path'] }}
+        INPUT_BASE_BRANCH: ${{ inputs['base-branch'] }}
+        INPUT_PROVIDER: ${{ inputs.provider }}
+        INPUT_NPM_VERSION: ${{ inputs['npm-version'] }}
+        INPUT_RELEASE_TAG: ${{ inputs['release-tag'] }}
+        INPUT_RELEASE_NAME: ${{ inputs['release-name'] }}
         INPUT_RELEASE_BODY: ${{ inputs['release-body'] }}
         INPUT_LANGUAGE: ${{ inputs.language }}
         INPUT_INSTRUCTIONS: ${{ inputs.instructions }}
         INPUT_INSTRUCTIONS_FILE: ${{ inputs['instructions-file'] }}
         INPUT_MINIMUM_PACKAGE_AGE_DAYS: ${{ inputs['minimum-package-age-days'] }}
+        INPUT_DRY_RUN: ${{ inputs['dry-run'] }}
       run: |
         set -euo pipefail
 
@@ -99,18 +110,29 @@ runs:
           # `minimum-release-age`: https://pnpm.io/npmrc#minimumreleaseage
           "--config.minimum-release-age=${MINIMUM_PACKAGE_AGE_MINUTES}"
           dlx
-          @nyaomaru/changelog-bot@"${{ inputs.npm-version }}"
-          --changelog-path "${{ inputs['changelog-path'] }}"
-          --base-branch "${{ inputs['base-branch'] }}"
-          --provider "${{ inputs.provider }}"
-          --language "${INPUT_LANGUAGE}"
+          @nyaomaru/changelog-bot@"${INPUT_NPM_VERSION:-latest}"
         )
 
-        if [ -n "${{ inputs['release-tag'] }}" ]; then
-          CMD+=(--release-tag "${{ inputs['release-tag'] }}")
+        if [ -n "${INPUT_CONFIG_PATH:-}" ]; then
+          CMD+=(--config "${INPUT_CONFIG_PATH}")
         fi
-        if [ -n "${{ inputs['release-name'] }}" ]; then
-          CMD+=(--release-name "${{ inputs['release-name'] }}")
+        if [ "${INPUT_CHANGELOG_PATH:-CHANGELOG.md}" != "CHANGELOG.md" ]; then
+          CMD+=(--changelog-path "${INPUT_CHANGELOG_PATH}")
+        fi
+        if [ "${INPUT_BASE_BRANCH:-main}" != "main" ]; then
+          CMD+=(--base-branch "${INPUT_BASE_BRANCH}")
+        fi
+        if [ "${INPUT_PROVIDER:-openai}" != "openai" ]; then
+          CMD+=(--provider "${INPUT_PROVIDER}")
+        fi
+        if [ "${INPUT_LANGUAGE:-en}" != "en" ]; then
+          CMD+=(--language "${INPUT_LANGUAGE}")
+        fi
+        if [ -n "${INPUT_RELEASE_TAG:-}" ]; then
+          CMD+=(--release-tag "${INPUT_RELEASE_TAG}")
+        fi
+        if [ -n "${INPUT_RELEASE_NAME:-}" ]; then
+          CMD+=(--release-name "${INPUT_RELEASE_NAME}")
         fi
         if [ -n "${INPUT_RELEASE_BODY:-}" ]; then
           CMD+=(--release-body "${INPUT_RELEASE_BODY}")
@@ -121,7 +143,7 @@ runs:
         if [ -n "${INPUT_INSTRUCTIONS_FILE:-}" ]; then
           CMD+=(--instructions-file "${INPUT_INSTRUCTIONS_FILE}")
         fi
-        if [ "${{ inputs['dry-run'] }}" = "true" ]; then
+        if [ "${INPUT_DRY_RUN:-false}" = "true" ]; then
           CMD+=(--dry-run)
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,6 @@ inputs:
   dry-run:
     description: "If 'true', print updated changelog without writing or PR"
     required: false
-    default: 'false'
 
 runs:
   using: 'composite'
@@ -142,8 +141,10 @@ runs:
         if [ -n "${INPUT_INSTRUCTIONS_FILE:-}" ]; then
           CMD+=(--instructions-file "${INPUT_INSTRUCTIONS_FILE}")
         fi
-        if [ "${INPUT_DRY_RUN:-false}" = "true" ]; then
+        if [ "${INPUT_DRY_RUN:-}" = "true" ]; then
           CMD+=(--dry-run)
+        elif [ "${INPUT_DRY_RUN:-}" = "false" ]; then
+          CMD+=(--no-dry-run)
         fi
 
         echo "+ ${CMD[@]}"

--- a/action.yml
+++ b/action.yml
@@ -6,21 +6,21 @@ branding:
   color: 'blue'
 
 inputs:
+  # WHY: CLI-backed inputs intentionally omit action metadata defaults. GitHub
+  # Actions exposes omitted inputs and default-valued explicit inputs the same
+  # way, so defaults here would make config-file precedence impossible to honor.
   changelog-path:
     description: 'Path to CHANGELOG file'
     required: false
-    default: 'CHANGELOG.md'
   config-path:
     description: 'Path to changelog-bot JSON config file'
     required: false
   base-branch:
     description: 'Base branch for the PR'
     required: false
-    default: 'main'
   provider:
     description: 'LLM provider to use (openai|anthropic|gemini)'
     required: false
-    default: 'openai'
   release-tag:
     description: 'Git ref (tag or HEAD) to generate changelog for'
     required: false
@@ -33,7 +33,6 @@ inputs:
   language:
     description: 'Language for generated changelog prose'
     required: false
-    default: 'en'
   instructions:
     description: 'Additional changelog writing and grouping instructions'
     required: false
@@ -116,16 +115,16 @@ runs:
         if [ -n "${INPUT_CONFIG_PATH:-}" ]; then
           CMD+=(--config "${INPUT_CONFIG_PATH}")
         fi
-        if [ "${INPUT_CHANGELOG_PATH:-CHANGELOG.md}" != "CHANGELOG.md" ]; then
+        if [ -n "${INPUT_CHANGELOG_PATH:-}" ]; then
           CMD+=(--changelog-path "${INPUT_CHANGELOG_PATH}")
         fi
-        if [ "${INPUT_BASE_BRANCH:-main}" != "main" ]; then
+        if [ -n "${INPUT_BASE_BRANCH:-}" ]; then
           CMD+=(--base-branch "${INPUT_BASE_BRANCH}")
         fi
-        if [ "${INPUT_PROVIDER:-openai}" != "openai" ]; then
+        if [ -n "${INPUT_PROVIDER:-}" ]; then
           CMD+=(--provider "${INPUT_PROVIDER}")
         fi
-        if [ "${INPUT_LANGUAGE:-en}" != "en" ]; then
+        if [ -n "${INPUT_LANGUAGE:-}" ]; then
           CMD+=(--language "${INPUT_LANGUAGE}")
         fi
         if [ -n "${INPUT_RELEASE_TAG:-}" ]; then

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,0 +1,2 @@
+/** Default CLI config file name loaded from the current working directory. */
+export const DEFAULT_CLI_CONFIG_FILE = 'changelog-bot.config.json';

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -2,48 +2,60 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { CliOptionsSchema, type CliOptions } from '@/schema/cli.js';
-import {
-  DEFAULT_BASE_BRANCH,
-  DEFAULT_CHANGELOG_FILE,
-} from '@/constants/git.js';
 import { PROVIDER_NAMES, PROVIDER_OPENAI } from '@/constants/provider.js';
 import type { ProviderName } from '@/types/llm.js';
+import { loadCliConfigFile } from '@/lib/config-file.js';
+
+type ParseCliArgsOptions = {
+  /** Directory used to resolve config files. */
+  cwd?: string;
+};
+
+function omitUndefined<T extends Record<string, unknown>>(
+  value: T,
+): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, fieldValue]) => fieldValue !== undefined),
+  ) as Partial<T>;
+}
 
 /**
  * Parse CLI arguments and normalize them with schema validation.
  * @param argv Raw argv array (typically `process.argv`).
+ * @param options Optional parser dependencies for tests.
  * @returns Validated CLI options.
  */
-export async function parseCliArgs(argv: string[]): Promise<CliOptions> {
+export async function parseCliArgs(
+  argv: string[],
+  options: ParseCliArgsOptions = {},
+): Promise<CliOptions> {
   const parsed = await yargs(hideBin(argv))
     // Force English help/messages regardless of system locale
     .locale('en')
-    .option('repo-path', { type: 'string', default: '.' })
-    .option('changelog-path', {
-      type: 'string',
-      default: DEFAULT_CHANGELOG_FILE,
-    })
-    .option('base-branch', { type: 'string', default: DEFAULT_BASE_BRANCH })
+    .option('config', { type: 'string' })
+    .option('repo-path', { type: 'string' })
+    .option('changelog-path', { type: 'string' })
+    .option('base-branch', { type: 'string' })
     .option('provider', {
       type: 'string',
       choices: [...PROVIDER_NAMES] as unknown as readonly string[],
-      default: PROVIDER_OPENAI,
     })
     .option('release-tag', { type: 'string' })
     .option('release-name', { type: 'string' })
-    .option('release-body', { type: 'string', default: '' })
-    .option('language', { type: 'string', default: 'en' })
+    .option('release-body', { type: 'string' })
+    .option('language', { type: 'string' })
     .option('instructions', { type: 'string' })
     .option('instructions-file', { type: 'string' })
-    .option('dry-run', { type: 'boolean', default: false })
+    .option('dry-run', { type: 'boolean' })
     .strict()
     .parse();
 
-  return CliOptionsSchema.parse({
+  const config = loadCliConfigFile(parsed.config, options.cwd);
+  const cliOverrides = omitUndefined({
     repoPath: parsed['repo-path'],
     changelogPath: parsed['changelog-path'],
     baseBranch: parsed['base-branch'],
-    provider: parsed.provider as ProviderName,
+    provider: parsed.provider as ProviderName | undefined,
     releaseTag: parsed['release-tag'],
     releaseName: parsed['release-name'],
     releaseBody: parsed['release-body'],
@@ -51,5 +63,11 @@ export async function parseCliArgs(argv: string[]): Promise<CliOptions> {
     instructions: parsed.instructions,
     instructionsFile: parsed['instructions-file'],
     dryRun: parsed['dry-run'],
+  });
+
+  return CliOptionsSchema.parse({
+    provider: PROVIDER_OPENAI,
+    ...config,
+    ...cliOverrides,
   });
 }

--- a/src/lib/config-file.ts
+++ b/src/lib/config-file.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { z } from 'zod';
+import { DEFAULT_CLI_CONFIG_FILE } from '@/constants/config.js';
+import {
+  CliConfigFileSchema,
+  type CliConfigFile,
+} from '@/schema/config-file.js';
+import { ConfigError } from '@/lib/errors.js';
+
+const CLI_CONFIG_ENCODING = 'utf8';
+
+/**
+ * Load optional CLI configuration from JSON.
+ * @param configPath Explicit config path; defaults to `changelog-bot.config.json`.
+ * @param cwd Directory used to resolve relative config paths.
+ * @returns Parsed config values, or an empty object when the default file is absent.
+ */
+export function loadCliConfigFile(
+  configPath?: string,
+  cwd = process.cwd(),
+): CliConfigFile {
+  const isExplicitConfig = Boolean(configPath);
+  const resolvedPath = resolve(cwd, configPath ?? DEFAULT_CLI_CONFIG_FILE);
+
+  if (!existsSync(resolvedPath)) {
+    if (isExplicitConfig) {
+      throw new ConfigError(`Config file not found: ${resolvedPath}`);
+    }
+    return {};
+  }
+
+  try {
+    const rawConfig = JSON.parse(
+      readFileSync(resolvedPath, CLI_CONFIG_ENCODING),
+    );
+    return CliConfigFileSchema.parse(rawConfig);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new ConfigError(
+        `Invalid config file ${resolvedPath}: ${z.prettifyError(error)}`,
+      );
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ConfigError(`Invalid config file ${resolvedPath}: ${message}`);
+  }
+}

--- a/src/schema/config-file.ts
+++ b/src/schema/config-file.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { PROVIDER_NAMES } from '@/constants/provider.js';
+
+/**
+ * Runtime validation for optional JSON config files.
+ * WHY: Config files are a public surface, so reject unknown keys early instead
+ * of silently ignoring typos.
+ */
+export const CliConfigFileSchema = z
+  .object({
+    repoPath: z.string().optional(),
+    changelogPath: z.string().optional(),
+    baseBranch: z.string().optional(),
+    provider: z.enum(PROVIDER_NAMES).optional(),
+    releaseTag: z.string().optional(),
+    releaseName: z.string().optional(),
+    releaseBody: z.string().optional(),
+    language: z.string().min(1).optional(),
+    instructions: z.string().optional(),
+    instructionsFile: z.string().optional(),
+    dryRun: z.boolean().optional(),
+  })
+  .strict();
+
+export type CliConfigFile = z.infer<typeof CliConfigFileSchema>;

--- a/tests/lib/cli-args.test.ts
+++ b/tests/lib/cli-args.test.ts
@@ -130,13 +130,14 @@ describe('cli-args', () => {
           PROVIDER_ANTHROPIC,
           '--language',
           'en',
+          '--no-dry-run',
         ],
         { cwd },
       );
 
       expect(out.provider).toBe(PROVIDER_ANTHROPIC);
       expect(out.language).toBe('en');
-      expect(out.dryRun).toBe(true);
+      expect(out.dryRun).toBe(false);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/lib/cli-args.test.ts
+++ b/tests/lib/cli-args.test.ts
@@ -1,4 +1,7 @@
 // @ts-nocheck
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { describe, expect, test } from '@jest/globals';
 
 import { parseCliArgs } from '@/lib/cli-args.js';
@@ -78,5 +81,64 @@ describe('cli-args', () => {
     ]);
 
     expect(out.provider).toBe(PROVIDER_GEMINI);
+  });
+
+  test('loads default config file from cwd', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'changelog-bot-'));
+    try {
+      writeFileSync(
+        join(cwd, 'changelog-bot.config.json'),
+        JSON.stringify({
+          provider: PROVIDER_GEMINI,
+          language: 'nl',
+          instructionsFile: '.github/changelog-instructions.md',
+        }),
+        'utf8',
+      );
+
+      const out = await parseCliArgs(['node', 'cli'], { cwd });
+
+      expect(out.provider).toBe(PROVIDER_GEMINI);
+      expect(out.language).toBe('nl');
+      expect(out.instructionsFile).toBe('.github/changelog-instructions.md');
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('lets CLI flags override config file values', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'changelog-bot-'));
+    try {
+      const configPath = join(cwd, 'custom-config.json');
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          provider: PROVIDER_GEMINI,
+          language: 'nl',
+          dryRun: true,
+        }),
+        'utf8',
+      );
+
+      const out = await parseCliArgs(
+        [
+          'node',
+          'cli',
+          '--config',
+          configPath,
+          '--provider',
+          PROVIDER_ANTHROPIC,
+          '--language',
+          'en',
+        ],
+        { cwd },
+      );
+
+      expect(out.provider).toBe(PROVIDER_ANTHROPIC);
+      expect(out.language).toBe('en');
+      expect(out.dryRun).toBe(true);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/lib/config-file.test.ts
+++ b/tests/lib/config-file.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, test } from '@jest/globals';
+import { loadCliConfigFile } from '@/lib/config-file.js';
+import { ConfigError } from '@/lib/errors.js';
+
+describe('loadCliConfigFile', () => {
+  test('returns empty config when default file is missing', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'changelog-bot-'));
+    try {
+      expect(loadCliConfigFile(undefined, cwd)).toEqual({});
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('throws when explicit config file is missing', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'changelog-bot-'));
+    try {
+      expect(() => loadCliConfigFile('missing.json', cwd)).toThrow(ConfigError);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects unknown config keys', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'changelog-bot-'));
+    try {
+      writeFileSync(
+        join(cwd, 'changelog-bot.config.json'),
+        JSON.stringify({ unknownOption: true }),
+        'utf8',
+      );
+
+      expect(() => loadCliConfigFile(undefined, cwd)).toThrow(ConfigError);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds JSON config file support for changelog-bot.

<!-- A brief summary of the changes -->

## Description

Adds JSON config file support for v0.4.

- Added default config loading from `changelog-bot.config.json`.
- Added `--config <path>` to load a custom JSON config file.
- Made CLI flags override config file values.
- Added strict config validation so unknown keys fail fast.
- Added `config-path` / `config_path` support to the composite action and reusable workflow.
- Updated `action.yml` to pass action inputs through environment variables before building the shell command.
- Documented config file usage and supported camelCase keys in the README.

<!-- A detailed explanation of the changes, including why they are needed -->
