### PR TITLE
fix(release): preserve prefixed section header

### DIFF
--- a/src/utils/release.ts
+++ b/src/utils/release.ts
@@ -11,6 +11,8 @@ import { BULLET_PREFIX_RE } from '@/constants/markdown.js';
 import { buildTitleLookup, findTitleMatch } from '@/utils/title-lookup.js';
 
 const H2_HEADING_RE = /^##\s+(.*)$/;
+const EMBEDDED_H2_HEADING_RE = /##\s+(.*)$/;
+const LETTER_OR_NUMBER_RE = /[\p{L}\p{N}]/u;
 const PR_URL_RE = /https?:\/\/\S+\/pull\/(\d+)/; // captures PR number
 const PR_REF_RE = /\(#?(\d+)\)|#(\d+)/; // (#123) or #123
 const AUTHOR_RE = /@([A-Za-z0-9_-]+)/;
@@ -116,7 +118,20 @@ function collectH2Sections(body: string): RawSection[] {
   let current: RawSection | null = null;
 
   for (const rawLine of lines) {
-    const headingMatch = rawLine.match(H2_HEADING_RE);
+    let headingMatch = rawLine.match(H2_HEADING_RE);
+    // WHY: When release-body text is copied or routed through workflow inputs,
+    // a stray prefix can appear before the first heading. Only triage pre-section
+    // lines this way so normal markdown inside sections keeps its literal text.
+    if (!headingMatch && !current && !sections.length) {
+      const embeddedHeadingMatch = rawLine.match(EMBEDDED_H2_HEADING_RE);
+      if (embeddedHeadingMatch) {
+        const headingStart = rawLine.indexOf('##');
+        const prefix = rawLine.slice(0, headingStart).trim();
+        if (!LETTER_OR_NUMBER_RE.test(prefix)) {
+          headingMatch = embeddedHeadingMatch;
+        }
+      }
+    }
     if (headingMatch) {
       if (current) sections.push(current);
       current = { heading: headingMatch[1].trim(), lines: [] };

--- a/src/utils/release.ts
+++ b/src/utils/release.ts
@@ -10,9 +10,9 @@ import { FULL_CHANGELOG_RE } from '@/constants/release.js';
 import { BULLET_PREFIX_RE } from '@/constants/markdown.js';
 import { buildTitleLookup, findTitleMatch } from '@/utils/title-lookup.js';
 
+const ATX_HEADING_RE = /^(#{1,6})(?!#)\s+(.*)$/;
 const H2_HEADING_RE = /^##\s+(.*)$/;
-const EMBEDDED_H2_HEADING_RE = /##\s+(.*)$/;
-const LETTER_OR_NUMBER_RE = /[\p{L}\p{N}]/u;
+const PREFIXED_ATX_HEADING_RE = /^([^\p{L}\p{N}#>*+-]+?)(#{1,6})(?!#)\s+(.*)$/u;
 const PR_URL_RE = /https?:\/\/\S+\/pull\/(\d+)/; // captures PR number
 const PR_REF_RE = /\(#?(\d+)\)|#(\d+)/; // (#123) or #123
 const AUTHOR_RE = /@([A-Za-z0-9_-]+)/;
@@ -43,6 +43,30 @@ type RawSection = {
  */
 function stripBulletPrefix(input: string): string {
   return input.replace(BULLET_PREFIX_RE, '').trim();
+}
+
+/**
+ * Normalize stray non-text prefixes before Markdown ATX headings.
+ * @param line Raw release-note line.
+ * @returns Line with accidental heading prefixes removed.
+ */
+function normalizeReleaseHeadingLine(line: string): string {
+  if (ATX_HEADING_RE.test(line)) return line;
+
+  const prefixedHeadingMatch = line.match(PREFIXED_ATX_HEADING_RE);
+  if (!prefixedHeadingMatch) return line;
+
+  return `${prefixedHeadingMatch[2]} ${prefixedHeadingMatch[3]}`;
+}
+
+/**
+ * Parse an H2 heading from a normalized release-note line.
+ * @param line Raw release-note line.
+ * @returns Heading text or `undefined` when the line is not an H2 heading.
+ */
+function parseReleaseHeading(line: string): string | undefined {
+  const headingMatch = line.match(H2_HEADING_RE);
+  return headingMatch ? headingMatch[1].trim() : undefined;
 }
 
 /**
@@ -118,27 +142,18 @@ function collectH2Sections(body: string): RawSection[] {
   let current: RawSection | null = null;
 
   for (const rawLine of lines) {
-    let headingMatch = rawLine.match(H2_HEADING_RE);
     // WHY: When release-body text is copied or routed through workflow inputs,
-    // a stray prefix can appear before the first heading. Only triage pre-section
-    // lines this way so normal markdown inside sections keeps its literal text.
-    if (!headingMatch && !current && !sections.length) {
-      const embeddedHeadingMatch = rawLine.match(EMBEDDED_H2_HEADING_RE);
-      if (embeddedHeadingMatch) {
-        const headingStart = rawLine.indexOf('##');
-        const prefix = rawLine.slice(0, headingStart).trim();
-        if (!LETTER_OR_NUMBER_RE.test(prefix)) {
-          headingMatch = embeddedHeadingMatch;
-        }
-      }
-    }
-    if (headingMatch) {
+    // stray non-text prefixes can appear before headings. Normalize ATX heading
+    // lines first, then only H2 headings become release-note section boundaries.
+    const line = normalizeReleaseHeadingLine(rawLine);
+    const heading = parseReleaseHeading(line);
+    if (heading) {
       if (current) sections.push(current);
-      current = { heading: headingMatch[1].trim(), lines: [] };
+      current = { heading, lines: [] };
       continue;
     }
     if (!current) continue;
-    current.lines.push(rawLine);
+    current.lines.push(line);
   }
 
   if (current) sections.push(current);

--- a/tests/utils/release.test.ts
+++ b/tests/utils/release.test.ts
@@ -74,6 +74,58 @@ describe('release utils', () => {
     );
   });
 
+  test('parseReleaseNotes triages stray prefix before the first custom heading', () => {
+    const body = [
+      '# v1.2.0',
+      '',
+      '\u2022 ## What\u2019s New \u{1F680}',
+      '- GitHub Action inputs respect config precedence.',
+      '',
+      '### Sample implementation',
+      '',
+      '```yaml',
+      '- uses: nyaomaru/changelog-bot@v0',
+      '```',
+      '',
+      '## What\u2019s Changed',
+      '- feat: add config file support by @alice in #321',
+      '',
+      '**Full Changelog**: v1.1.13...v1.2.0',
+    ].join('\n');
+
+    const parsed = parseReleaseNotes(body, { owner: 'acme', repo: 'repo' });
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.sections).toEqual([
+      {
+        heading: 'What\u2019s New \u{1F680}',
+        body: [
+          '- GitHub Action inputs respect config precedence.',
+          '',
+          '### Sample implementation',
+          '',
+          '```yaml',
+          '- uses: nyaomaru/changelog-bot@v0',
+          '```',
+        ].join('\n'),
+      },
+    ]);
+  });
+
+  test('parseReleaseNotes does not promote prose before an embedded heading marker', () => {
+    const body = [
+      'Release summary ## Not a Heading',
+      '',
+      '## What\u2019s Changed',
+      '- feat: add config file support by @alice in #321',
+    ].join('\n');
+
+    const parsed = parseReleaseNotes(body, { owner: 'acme', repo: 'repo' });
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.sections).toBeUndefined();
+  });
+
   test('parseReleaseNotes strips trailing attribution noise after PR and author extraction', () => {
     const body = [
       '# v0.2.0',

--- a/tests/utils/release.test.ts
+++ b/tests/utils/release.test.ts
@@ -126,6 +126,79 @@ describe('release utils', () => {
     expect(parsed.sections).toBeUndefined();
   });
 
+  test('parseReleaseNotes keeps H3 headings inside custom section bodies', () => {
+    const body = [
+      '## What\u2019s New',
+      'Highlights for this release.',
+      '',
+      '\u2022 ### Sample implementation',
+      'Use the action from workflow YAML.',
+    ].join('\n');
+
+    const parsed = parseReleaseNotes(body, { owner: 'acme', repo: 'repo' });
+
+    expect(parsed.sections).toEqual([
+      {
+        heading: 'What\u2019s New',
+        body: [
+          'Highlights for this release.',
+          '',
+          '### Sample implementation',
+          'Use the action from workflow YAML.',
+        ].join('\n'),
+      },
+    ]);
+  });
+
+  test('parseReleaseNotes normalizes noisy non-H2 headings without making them section boundaries', () => {
+    const body = [
+      '## What\u2019s New',
+      '\u2022 # Context',
+      'Release-level context stays in the custom section body.',
+      '',
+      '> ## Quoted heading stays literal',
+      '- ### List heading stays literal',
+    ].join('\n');
+
+    const parsed = parseReleaseNotes(body, { owner: 'acme', repo: 'repo' });
+
+    expect(parsed.sections).toEqual([
+      {
+        heading: 'What\u2019s New',
+        body: [
+          '# Context',
+          'Release-level context stays in the custom section body.',
+          '',
+          '> ## Quoted heading stays literal',
+          '- ### List heading stays literal',
+        ].join('\n'),
+      },
+    ]);
+  });
+
+  test('parseReleaseNotes triages stray prefix before generated notes headings', () => {
+    const body = [
+      '# v1.2.0',
+      '',
+      '\u2022 ## What\u2019s Changed',
+      '- feat: add config file support by @alice in #321',
+      '',
+      '\u2022 ## Migration Notes',
+      'No migration steps required.',
+    ].join('\n');
+
+    const parsed = parseReleaseNotes(body, { owner: 'acme', repo: 'repo' });
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0].title).toBe('add config file support');
+    expect(parsed.sections).toEqual([
+      {
+        heading: 'Migration Notes',
+        body: 'No migration steps required.',
+      },
+    ]);
+  });
+
   test('parseReleaseNotes strips trailing attribution noise after PR and author extraction', () => {
     const body = [
       '# v0.2.0',


### PR DESCRIPTION
## Summary

Preserve prefixed section header.

<!-- A brief summary of the changes -->

## Description

- Preserve custom release-note sections when stray prefix characters appear before the first `#` / `##` / `###`heading.
- Keep normal H1 / H2 / H3 parsing strict, and only triage pre-section lines whose prefix before `#` / `##` / `### is non-text noise.
- Add regression coverage for both the prefixed `What’s New` case and prose containing an embedded `#` / `##` / `###.

<!-- A detailed explanation of the changes, including why they are needed -->
