### PR TITLE
feat: add reliability controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 dist
 node_modules
 env
-
+.serena

--- a/README.md
+++ b/README.md
@@ -41,20 +41,24 @@ Using it in CI? Jump to [GitHub Actions integration](#github-actions-integration
 
 ### Options
 
-| Option                | Description                                         | Default                                |
-| --------------------- | --------------------------------------------------- | -------------------------------------- |
-| `--repo-path`         | Path to repository root                             | `.`                                    |
-| `--config`            | Path to JSON config file                            | `changelog-bot.config.json` if present |
-| `--changelog-path`    | Path to CHANGELOG file                              | `CHANGELOG.md`                         |
-| `--base-branch`       | Base branch for PR                                  | `main`                                 |
-| `--provider`          | LLM provider (`openai`, `anthropic`, or `gemini`)   | `openai`                               |
-| `--release-tag`       | Git ref (tag or HEAD) to generate release for       | latest tag or HEAD                     |
-| `--release-name`      | Display name for version (without `v`)              | derived from tag                       |
-| `--release-body`      | Additional release notes body                       | `""`                                   |
-| `--language`          | Language for generated changelog prose              | `en`                                   |
-| `--instructions`      | Additional changelog writing/grouping instructions  | unset                                  |
-| `--instructions-file` | Path to a file with additional instructions         | unset                                  |
-| `--dry-run`           | Print updated CHANGELOG to stdout, don’t write file | `false`                                |
+| Option                  | Description                                           | Default                                |
+| ----------------------- | ----------------------------------------------------- | -------------------------------------- |
+| `--repo-path`           | Path to repository root                               | `.`                                    |
+| `--config`              | Path to JSON config file                              | `changelog-bot.config.json` if present |
+| `--changelog-path`      | Path to CHANGELOG file                                | `CHANGELOG.md`                         |
+| `--base-branch`         | Base branch for PR                                    | `main`                                 |
+| `--provider`            | LLM provider (`openai`, `anthropic`, or `gemini`)     | `openai`                               |
+| `--release-tag`         | Git ref (tag or HEAD) to generate release for         | latest tag or HEAD                     |
+| `--release-name`        | Display name for version (without `v`)                | derived from tag                       |
+| `--release-body`        | Additional release notes body                         | `""`                                   |
+| `--language`            | Language for generated changelog prose                | `en`                                   |
+| `--instructions`        | Additional changelog writing/grouping instructions    | unset                                  |
+| `--instructions-file`   | Path to a file with additional instructions           | unset                                  |
+| `--dry-run`             | Print updated CHANGELOG to stdout, don’t write file   | `false`                                |
+| `--dry-run-json-report` | Print dry-run provider diagnostics as JSON            | `false`                                |
+| `--fail-on-llm-error`   | Fail instead of falling back when provider calls fail | `false`                                |
+| `--require-provider`    | Fail when the selected provider API key is missing    | `false`                                |
+| `--no-ai`               | Skip all provider calls and use deterministic output  | `false`                                |
 
 ## Examples
 
@@ -70,7 +74,9 @@ pnpm dlx @nyaomaru/changelog-bot \
 ```
 
 Dry-runs print provider diagnostics before the generated changelog so you can
-confirm whether an LLM request was used or the run fell back.
+confirm whether an LLM request was used or the run fell back. Add
+`--dry-run-json-report` to print that diagnostics block as JSON with `provider`,
+`model`, `aiUsed`, and `fallbackReasons`.
 
 ### Generate changelog for a tagged release
 
@@ -84,7 +90,7 @@ pnpm dlx @nyaomaru/changelog-bot \
 
 ### Run without AI keys (fallback)
 
-If the selected provider API key is not set, the CLI skips model calls and builds a heuristic section from git logs (or uses GitHub Release Notes when provided). The PR body includes a note with the fallback reason, so everyone knows the run was deterministic.
+If the selected provider API key is not set, the CLI skips model calls and builds a heuristic section from git logs (or uses GitHub Release Notes when provided). The PR body includes a note with the fallback reason, so everyone knows the run was deterministic. Use `--require-provider` to fail instead when the key is missing, `--fail-on-llm-error` to fail on provider API/schema failures, or `--no-ai` to skip provider calls intentionally.
 
 ```sh
 # No AI keys in env
@@ -146,7 +152,8 @@ pnpm dlx @nyaomaru/changelog-bot --config .github/changelog-bot.json --dry-run
 Config files use camelCase keys matching the CLI options:
 `repoPath`, `changelogPath`, `baseBranch`, `provider`, `releaseTag`,
 `releaseName`, `releaseBody`, `language`, `instructions`,
-`instructionsFile`, and `dryRun`. Unknown keys are rejected so typos fail fast.
+`instructionsFile`, `dryRun`, `dryRunJsonReport`, `failOnLlmError`,
+`requireProvider`, and `noAi`. Unknown keys are rejected so typos fail fast.
 
 ### From source (local checkout)
 
@@ -173,6 +180,9 @@ Bring your own keys and tokens as needed—`changelog-bot` only asks for what it
 ### Fallback behavior (when AI is unavailable)
 
 - Missing AI keys or API failure does not fail the run.
+- `--require-provider` makes missing provider keys fail the run.
+- `--fail-on-llm-error` makes provider generation/classification failures fail the run.
+- `--no-ai` skips provider generation and title classification entirely.
 - If GitHub Release Notes are provided for the tag, they are used as the source of truth.
 - Otherwise, a heuristic section is built from `git log` and merged PRs.
 - The PR body is annotated with: “Generated without LLM. Reason: …”.
@@ -293,6 +303,10 @@ Action inputs (for both 1 and 3):
 - `instructions`: extra changelog writing and grouping instructions.
 - `instructions-file` / `instructions_file`: path to an instructions file, relative to the repository root.
 - `dry-run` / `dry_run`: `'true'` to print without writing/PR; explicitly set `'false'` to override `dryRun: true` from config.
+- `dry-run-json-report` / `dry_run_json_report`: `'true'` to print dry-run provider diagnostics as JSON.
+- `fail-on-llm-error` / `fail_on_llm_error`: `'true'` to fail instead of falling back when provider calls fail.
+- `require-provider` / `require_provider`: `'true'` to fail when the selected provider API key is missing.
+- `no-ai` / `no_ai`: `'true'` to skip all provider calls and use deterministic output.
 
 When `config-path` is used, omitted action inputs can be supplied by the config file. Inputs that are explicitly set in workflow YAML are forwarded as CLI flags and take precedence over config values, even when the value matches the documented default.
 

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,18 @@ inputs:
   dry-run:
     description: "If 'true', print updated changelog without writing or PR"
     required: false
+  dry-run-json-report:
+    description: "If 'true', print dry-run provider diagnostics as JSON"
+    required: false
+  fail-on-llm-error:
+    description: "If 'true', fail instead of falling back when provider calls fail"
+    required: false
+  require-provider:
+    description: "If 'true', fail when the selected provider API key is missing"
+    required: false
+  no-ai:
+    description: "If 'true', skip all provider calls and use deterministic output"
+    required: false
 
 runs:
   using: 'composite'
@@ -90,6 +102,10 @@ runs:
         INPUT_INSTRUCTIONS_FILE: ${{ inputs['instructions-file'] }}
         INPUT_MINIMUM_PACKAGE_AGE_DAYS: ${{ inputs['minimum-package-age-days'] }}
         INPUT_DRY_RUN: ${{ inputs['dry-run'] }}
+        INPUT_DRY_RUN_JSON_REPORT: ${{ inputs['dry-run-json-report'] }}
+        INPUT_FAIL_ON_LLM_ERROR: ${{ inputs['fail-on-llm-error'] }}
+        INPUT_REQUIRE_PROVIDER: ${{ inputs['require-provider'] }}
+        INPUT_NO_AI: ${{ inputs['no-ai'] }}
       run: |
         set -euo pipefail
 
@@ -145,6 +161,26 @@ runs:
           CMD+=(--dry-run)
         elif [ "${INPUT_DRY_RUN:-}" = "false" ]; then
           CMD+=(--no-dry-run)
+        fi
+        if [ "${INPUT_DRY_RUN_JSON_REPORT:-}" = "true" ]; then
+          CMD+=(--dry-run-json-report)
+        elif [ "${INPUT_DRY_RUN_JSON_REPORT:-}" = "false" ]; then
+          CMD+=(--no-dry-run-json-report)
+        fi
+        if [ "${INPUT_FAIL_ON_LLM_ERROR:-}" = "true" ]; then
+          CMD+=(--fail-on-llm-error)
+        elif [ "${INPUT_FAIL_ON_LLM_ERROR:-}" = "false" ]; then
+          CMD+=(--no-fail-on-llm-error)
+        fi
+        if [ "${INPUT_REQUIRE_PROVIDER:-}" = "true" ]; then
+          CMD+=(--require-provider)
+        elif [ "${INPUT_REQUIRE_PROVIDER:-}" = "false" ]; then
+          CMD+=(--no-require-provider)
+        fi
+        if [ "${INPUT_NO_AI:-}" = "true" ]; then
+          CMD+=(--no-ai)
+        elif [ "${INPUT_NO_AI:-}" = "false" ]; then
+          CMD+=(--ai)
         fi
 
         echo "+ ${CMD[@]}"

--- a/src/lib/changelog-run.ts
+++ b/src/lib/changelog-run.ts
@@ -14,7 +14,10 @@ import {
 } from '@/lib/release-context.js';
 import { finalizeChangelogUpdate } from '@/lib/changelog-update.js';
 import { resolveCustomInstructions } from '@/lib/customization.js';
-import { formatDryRunDiagnostics } from '@/utils/dry-run-diagnostics.js';
+import {
+  formatDryRunDiagnostics,
+  formatDryRunJsonReport,
+} from '@/utils/dry-run-diagnostics.js';
 import {
   DEFAULT_PR_LABELS,
   PR_BRANCH_PREFIX,
@@ -184,6 +187,9 @@ export async function executeChangelogRun(params: {
     hasProviderKey,
     token,
     githubApiBase: appConfig.github.apiBase,
+    noAi: cli.noAi,
+    requireProvider: cli.requireProvider,
+    failOnLlmError: cli.failOnLlmError,
   });
   let llm = llmOutput.llm;
 
@@ -202,13 +208,16 @@ export async function executeChangelogRun(params: {
 
   if (cli.dryRun) {
     log('==== DRY RUN (no PR) ====');
+    const diagnosticsInput = {
+      providerName: provider.name,
+      modelName: providerConfig.model,
+      aiUsed: llmOutput.aiUsed,
+      fallbackReasons: llmOutput.fallbackReasons,
+    };
     log(
-      formatDryRunDiagnostics({
-        providerName: provider.name,
-        modelName: providerConfig.model,
-        aiUsed: llmOutput.aiUsed,
-        fallbackReasons: llmOutput.fallbackReasons,
-      }),
+      cli.dryRunJsonReport
+        ? formatDryRunJsonReport(diagnosticsInput)
+        : formatDryRunDiagnostics(diagnosticsInput),
     );
     log('');
     log(updated);

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -47,6 +47,10 @@ export async function parseCliArgs(
     .option('instructions', { type: 'string' })
     .option('instructions-file', { type: 'string' })
     .option('dry-run', { type: 'boolean' })
+    .option('dry-run-json-report', { type: 'boolean' })
+    .option('fail-on-llm-error', { type: 'boolean' })
+    .option('require-provider', { type: 'boolean' })
+    .option('ai', { type: 'boolean' })
     .strict()
     .parse();
 
@@ -63,6 +67,10 @@ export async function parseCliArgs(
     instructions: parsed.instructions,
     instructionsFile: parsed['instructions-file'],
     dryRun: parsed['dry-run'],
+    dryRunJsonReport: parsed['dry-run-json-report'],
+    failOnLlmError: parsed['fail-on-llm-error'],
+    requireProvider: parsed['require-provider'],
+    noAi: parsed.ai === undefined ? undefined : !parsed.ai,
   });
 
   return CliOptionsSchema.parse({

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,6 +1,6 @@
 import type { LLMInput, LLMOutput } from '@/types/llm.js';
 import type { ProviderRuntimeConfig } from '@/types/config.js';
-import type { Provider } from '@/types/provider.js';
+import type { ClassifyTitlesOptions, Provider } from '@/types/provider.js';
 import { outputSchema } from '@/utils/output-json-schema.js';
 import { extractJsonObject } from '@/utils/json-extract.js';
 import { postJson } from '@/utils/http.js';
@@ -103,7 +103,10 @@ export class AnthropicProvider implements Provider {
     return extractJsonObject<LLMOutput>(outputText);
   }
 
-  async classifyTitles(titles: string[]): Promise<CategoryMap> {
+  async classifyTitles(
+    titles: string[],
+    options: ClassifyTitlesOptions = {},
+  ): Promise<CategoryMap> {
     if (!titles.length) return {};
     if (!this.apiKey) return fallbackCategoryMap(titles);
 
@@ -145,8 +148,13 @@ export class AnthropicProvider implements Provider {
         'Anthropic classify error',
       );
       const text = extractAnthropicClassificationResponse(json) || '{}';
-      return parseCategoryMap(text) ?? fallbackCategoryMap(titles);
-    } catch {
+      const categories = parseCategoryMap(text);
+      if (!categories) {
+        throw new Error('Anthropic classify output did not match schema');
+      }
+      return categories;
+    } catch (err) {
+      if (options.throwOnError) throw err;
       return fallbackCategoryMap(titles);
     }
   }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,6 +1,6 @@
 import type { LLMInput, LLMOutput } from '@/types/llm.js';
 import type { ProviderRuntimeConfig } from '@/types/config.js';
-import type { Provider } from '@/types/provider.js';
+import type { ClassifyTitlesOptions, Provider } from '@/types/provider.js';
 import type { CategoryMap } from '@/types/changelog.js';
 import { outputSchema } from '@/utils/output-json-schema.js';
 import { extractJsonObject } from '@/utils/json-extract.js';
@@ -115,7 +115,10 @@ export class GeminiProvider implements Provider {
     return extractJsonObject<LLMOutput>(extractGeminiText(response));
   }
 
-  async classifyTitles(titles: string[]): Promise<CategoryMap> {
+  async classifyTitles(
+    titles: string[],
+    options: ClassifyTitlesOptions = {},
+  ): Promise<CategoryMap> {
     if (!titles.length) return {};
     if (!this.apiKey) return fallbackCategoryMap(titles);
 
@@ -155,11 +158,13 @@ export class GeminiProvider implements Provider {
         { 'x-goog-api-key': this.apiKey },
         'Gemini classify error',
       );
-      return (
-        parseCategoryMap(extractGeminiText(response)) ??
-        fallbackCategoryMap(titles)
-      );
-    } catch {
+      const categories = parseCategoryMap(extractGeminiText(response));
+      if (!categories) {
+        throw new Error('Gemini classify output did not match schema');
+      }
+      return categories;
+    } catch (err) {
+      if (options.throwOnError) throw err;
       return fallbackCategoryMap(titles);
     }
   }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,6 +1,6 @@
 import type { LLMInput, LLMOutput } from '@/types/llm.js';
 import type { ProviderRuntimeConfig } from '@/types/config.js';
-import type { Provider } from '@/types/provider.js';
+import type { ClassifyTitlesOptions, Provider } from '@/types/provider.js';
 import { outputSchema } from '@/utils/output-json-schema.js';
 import { extractJsonObject } from '@/utils/json-extract.js';
 import { postJson } from '@/utils/http.js';
@@ -106,7 +106,10 @@ export class OpenAIProvider implements Provider {
     return extractJsonObject<LLMOutput>(outputText);
   }
 
-  async classifyTitles(titles: string[]): Promise<CategoryMap> {
+  async classifyTitles(
+    titles: string[],
+    options: ClassifyTitlesOptions = {},
+  ): Promise<CategoryMap> {
     if (!titles.length) return {};
     if (!this.apiKey) return fallbackCategoryMap(titles);
 
@@ -131,8 +134,13 @@ export class OpenAIProvider implements Provider {
         'OpenAI classify error',
       );
       const text = extractOpenAiClassificationResponse(json);
-      return parseCategoryMap(text) ?? fallbackCategoryMap(titles);
-    } catch {
+      const categories = parseCategoryMap(text);
+      if (!categories) {
+        throw new Error('OpenAI classify output did not match schema');
+      }
+      return categories;
+    } catch (err) {
+      if (options.throwOnError) throw err;
       return fallbackCategoryMap(titles);
     }
   }

--- a/src/schema/cli.ts
+++ b/src/schema/cli.ts
@@ -9,18 +9,32 @@ import { PROVIDER_NAMES } from '@/constants/provider.js';
  * Runtime validation for CLI options after yargs parsing.
  * WHY: Ensures consistent shapes and supported values across the app.
  */
-export const CliOptionsSchema = z.object({
-  repoPath: z.string().default('.'),
-  changelogPath: z.string().default(DEFAULT_CHANGELOG_FILE),
-  baseBranch: z.string().default(DEFAULT_BASE_BRANCH),
-  provider: z.enum(PROVIDER_NAMES),
-  releaseTag: z.string().optional(),
-  releaseName: z.string().optional(),
-  releaseBody: z.string().default(''),
-  language: z.string().min(1).default('en'),
-  instructions: z.string().optional(),
-  instructionsFile: z.string().optional(),
-  dryRun: z.boolean().default(false),
-});
+export const CliOptionsSchema = z
+  .object({
+    repoPath: z.string().default('.'),
+    changelogPath: z.string().default(DEFAULT_CHANGELOG_FILE),
+    baseBranch: z.string().default(DEFAULT_BASE_BRANCH),
+    provider: z.enum(PROVIDER_NAMES),
+    releaseTag: z.string().optional(),
+    releaseName: z.string().optional(),
+    releaseBody: z.string().default(''),
+    language: z.string().min(1).default('en'),
+    instructions: z.string().optional(),
+    instructionsFile: z.string().optional(),
+    dryRun: z.boolean().default(false),
+    dryRunJsonReport: z.boolean().default(false),
+    failOnLlmError: z.boolean().default(false),
+    requireProvider: z.boolean().default(false),
+    noAi: z.boolean().default(false),
+  })
+  .superRefine((options, context) => {
+    if (options.noAi && options.requireProvider) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['noAi'],
+        message: '--no-ai cannot be combined with --require-provider',
+      });
+    }
+  });
 
 export type CliOptions = z.infer<typeof CliOptionsSchema>;

--- a/src/schema/config-file.ts
+++ b/src/schema/config-file.ts
@@ -19,6 +19,10 @@ export const CliConfigFileSchema = z
     instructions: z.string().optional(),
     instructionsFile: z.string().optional(),
     dryRun: z.boolean().optional(),
+    dryRunJsonReport: z.boolean().optional(),
+    failOnLlmError: z.boolean().optional(),
+    requireProvider: z.boolean().optional(),
+    noAi: z.boolean().optional(),
   })
   .strict();
 

--- a/src/types/changelog-output.ts
+++ b/src/types/changelog-output.ts
@@ -49,6 +49,12 @@ export type BuildChangelogLlmOutputParams = {
   token?: string;
   /** GitHub or GHES API base URL. */
   githubApiBase: string;
+  /** Skip all provider calls and force deterministic release-note/fallback output. */
+  noAi: boolean;
+  /** Fail when the selected provider has no configured API key. */
+  requireProvider: boolean;
+  /** Fail instead of falling back when a provider generation/classification call fails. */
+  failOnLlmError: boolean;
 };
 
 /** Result payload for the changelog LLM output builder. */

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -23,6 +23,12 @@ export type ProviderInfo = {
   supports: ProviderCapabilities;
 };
 
+/** Options controlling provider title classification error handling. */
+export type ClassifyTitlesOptions = {
+  /** Throw provider/parse errors instead of returning deterministic fallback categories. */
+  throwOnError?: boolean;
+};
+
 /**
  * Contract implemented by LLM provider adapters.
  * Implementations should normalize outputs at this boundary.
@@ -31,5 +37,8 @@ export interface Provider extends ProviderInfo {
   /** Generate structured output from normalized input. */
   generate(input: LLMInput): Promise<LLMOutput>;
   /** Classify titles into changelog categories. */
-  classifyTitles(titles: string[]): Promise<CategoryMap>;
+  classifyTitles(
+    titles: string[],
+    options?: ClassifyTitlesOptions,
+  ): Promise<CategoryMap>;
 }

--- a/src/utils/dry-run-diagnostics.ts
+++ b/src/utils/dry-run-diagnostics.ts
@@ -12,6 +12,18 @@ export type DryRunDiagnosticsInput = {
   fallbackReasons: string[];
 };
 
+/** Machine-readable dry-run report printed when requested by CLI flag. */
+export type DryRunJsonReport = {
+  /** Provider selected for the run. */
+  provider: ProviderName;
+  /** Model configured for the selected provider. */
+  model: string;
+  /** Whether any provider request completed successfully. */
+  aiUsed: boolean;
+  /** Reasons explaining fallback behavior when provider usage was skipped or failed. */
+  fallbackReasons: string[];
+};
+
 /**
  * Format provider diagnostics for dry-run output.
  * @param input Provider, model, and fallback state for the current run.
@@ -28,4 +40,20 @@ export function formatDryRunDiagnostics(input: DryRunDiagnosticsInput): string {
     `AI used: ${input.aiUsed ? 'true' : 'false'}`,
     `Fallback reasons: ${fallbackReasonText}`,
   ].join('\n');
+}
+
+/**
+ * Format provider diagnostics as stable JSON for dry-run automation.
+ * @param input Provider, model, and fallback state for the current run.
+ * @returns Pretty-printed JSON report.
+ */
+export function formatDryRunJsonReport(input: DryRunDiagnosticsInput): string {
+  const report: DryRunJsonReport = {
+    provider: input.providerName,
+    model: input.modelName,
+    aiUsed: input.aiUsed,
+    fallbackReasons: input.fallbackReasons,
+  };
+
+  return JSON.stringify(report, null, 2);
 }

--- a/src/utils/llm-output-model.ts
+++ b/src/utils/llm-output-model.ts
@@ -18,6 +18,7 @@ import {
   applyLlmDefaults,
   buildAutoPrBody,
 } from '@/utils/llm-output-common.js';
+import { LlmError } from '@/lib/errors.js';
 
 function buildLogsForLLM(
   commitList: CommitLite[],
@@ -54,6 +55,8 @@ export async function buildOutputFromModelOrFallback(
     prMapBySha,
     provider,
     hasProviderKey,
+    noAi,
+    failOnLlmError,
   } = params;
 
   const logsForLLM = buildLogsForLLM(commitList, prMapBySha);
@@ -75,7 +78,9 @@ export async function buildOutputFromModelOrFallback(
   let aiUsed = false;
   let llm: LLMOutput | null = null;
 
-  if (!hasProviderKey) {
+  if (noAi) {
+    // The caller has already recorded the flag in fallbackReasons.
+  } else if (!hasProviderKey) {
     fallbackReasons.push(`Missing API key for provider: ${provider.name}`);
   } else {
     try {
@@ -83,6 +88,9 @@ export async function buildOutputFromModelOrFallback(
       aiUsed = true;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      if (failOnLlmError) {
+        throw new LlmError(`LLM generation failed: ${message}`);
+      }
       fallbackReasons.push(`LLM generation failed: ${message}`);
     }
   }

--- a/src/utils/llm-output-model.ts
+++ b/src/utils/llm-output-model.ts
@@ -89,7 +89,7 @@ export async function buildOutputFromModelOrFallback(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       if (failOnLlmError) {
-        throw new LlmError(`LLM generation failed: ${message}`);
+        throw err instanceof Error ? err : new LlmError(`LLM generation failed: ${message}`);
       }
       fallbackReasons.push(`LLM generation failed: ${message}`);
     }

--- a/src/utils/llm-output-release-notes.ts
+++ b/src/utils/llm-output-release-notes.ts
@@ -2,6 +2,8 @@ import { fetchPRInfo } from '@/lib/github.js';
 import { parseReleaseNotes, buildSectionFromRelease } from '@/utils/release.js';
 import { tuneCategoriesByTitle } from '@/utils/category-tune.js';
 import { buildTitlesForClassification } from '@/utils/classify-pre.js';
+import { fallbackCategoryMap } from '@/providers/classification.js';
+import { LlmError } from '@/lib/errors.js';
 import {
   DEFAULT_PR_LABELS,
   PR_TITLE_PREFIX,
@@ -85,6 +87,8 @@ export async function buildOutputFromReleaseNotes(
     titleToPr,
     provider,
     hasProviderKey,
+    noAi,
+    failOnLlmError,
     token,
     githubApiBase,
   } = params;
@@ -110,9 +114,22 @@ export async function buildOutputFromReleaseNotes(
   const titlesForLLM = buildTitlesForClassification(parsedRelease.items);
   let categories: Record<string, string[]> = {};
   if (titlesForLLM.length) {
-    categories = await provider.classifyTitles(titlesForLLM);
-    // Mark AI usage only when classification had input and a provider key is available.
-    aiUsed = aiUsed || hasProviderKey;
+    if (noAi) {
+      categories = fallbackCategoryMap(titlesForLLM);
+    } else {
+      try {
+        categories = await provider.classifyTitles(titlesForLLM);
+        // Mark AI usage only when classification had input and a provider key is available.
+        aiUsed = aiUsed || hasProviderKey;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (failOnLlmError) {
+          throw new LlmError(`LLM classification failed: ${message}`);
+        }
+        fallbackReasons.push(`LLM classification failed: ${message}`);
+        categories = fallbackCategoryMap(titlesForLLM);
+      }
+    }
     // Heuristic tuning: ensure typing/contract corrections are grouped under Fixed.
     categories = tuneCategoriesByTitle(parsedRelease.items, categories);
   }

--- a/src/utils/llm-output-release-notes.ts
+++ b/src/utils/llm-output-release-notes.ts
@@ -118,7 +118,9 @@ export async function buildOutputFromReleaseNotes(
       categories = fallbackCategoryMap(titlesForLLM);
     } else {
       try {
-        categories = await provider.classifyTitles(titlesForLLM);
+        categories = await provider.classifyTitles(titlesForLLM, {
+          throwOnError: true,
+        });
         // Mark AI usage only when classification had input and a provider key is available.
         aiUsed = aiUsed || hasProviderKey;
       } catch (err) {

--- a/src/utils/llm-output.ts
+++ b/src/utils/llm-output.ts
@@ -1,5 +1,6 @@
 import { buildOutputFromReleaseNotes } from '@/utils/llm-output-release-notes.js';
 import { buildOutputFromModelOrFallback } from '@/utils/llm-output-model.js';
+import { LlmError } from '@/lib/errors.js';
 import type {
   BuildChangelogLlmOutputParams,
   BuildLlmOutputResult,
@@ -15,11 +16,20 @@ export async function buildChangelogLlmOutput(
   params: BuildChangelogLlmOutputParams,
 ): Promise<BuildLlmOutputResult> {
   const fallbackReasons: string[] = [];
+  if (params.noAi) {
+    fallbackReasons.push('AI disabled by --no-ai');
+  }
+  if (params.requireProvider && !params.hasProviderKey) {
+    throw new LlmError(
+      `Provider required but API key is missing for provider: ${params.provider.name}`,
+    );
+  }
+
   const hasCustomization = Boolean(
     params.customInstructions || params.language !== 'en',
   );
 
-  if (!hasCustomization || !params.hasProviderKey) {
+  if (params.noAi || !hasCustomization || !params.hasProviderKey) {
     const fromRelease = await buildOutputFromReleaseNotes(
       params,
       fallbackReasons,

--- a/tests/lib/changelog-run.test.ts
+++ b/tests/lib/changelog-run.test.ts
@@ -15,6 +15,10 @@ const cli = {
   instructions: 'Use concise bullets.',
   instructionsFile: '.github/changelog-instructions.md',
   dryRun: true,
+  dryRunJsonReport: false,
+  failOnLlmError: false,
+  requireProvider: false,
+  noAi: false,
 };
 
 const appConfig = {
@@ -113,6 +117,9 @@ describe('executeChangelogRun', () => {
         prs: 'merged prs',
         existingChangelog: 'existing changelog',
         provider,
+        noAi: false,
+        requireProvider: false,
+        failOnLlmError: false,
       }),
     );
     expect(log).toHaveBeenNthCalledWith(1, '==== DRY RUN (no PR) ====');
@@ -127,5 +134,74 @@ describe('executeChangelogRun', () => {
     );
     expect(log).toHaveBeenNthCalledWith(3, '');
     expect(log).toHaveBeenNthCalledWith(4, 'updated changelog');
+  });
+
+  test('dry-run can print provider diagnostics as JSON report', async () => {
+    const log = jest.fn();
+    const deps = {
+      providerFactory: jest.fn(() => provider),
+      getRepoFullName: jest.fn(() => 'octo/repo'),
+      resolveReleasePlan: jest.fn(() => ({
+        owner: 'octo',
+        repo: 'repo',
+        repoPath: '.',
+        changelogPath: 'CHANGELOG.md',
+        releaseRef: 'v1.2.3',
+        version: '1.2.3',
+        prevRef: 'v1.2.2',
+        date: '2026-05-23',
+      })),
+      gitMergedPRs: jest.fn(() => 'merged prs'),
+      commitsInRange: jest.fn(() => []),
+      prepareExistingChangelog: jest.fn(() => 'existing changelog'),
+      resolveRunCredentials: jest.fn(async () => ({
+        token: undefined,
+        hasProviderKey: false,
+      })),
+      mapCommitsToPrs: jest.fn(),
+      fetchReleaseBody: jest.fn(),
+      resolveCustomInstructions: jest.fn(() => undefined),
+      buildPrMapBySha: jest.fn(() => ({})),
+      buildTitleToPr: jest.fn(() => ({})),
+      getProviderRuntimeConfig: jest.fn(() => appConfig.providers.openai),
+      buildChangelogLlmOutput: jest.fn(async () => ({
+        llm: {
+          new_section_markdown: 'generated section',
+          insert_after_anchor: '## [Unreleased]',
+          pr_title: 'docs(changelog): 1.2.3',
+          pr_body: 'body',
+          labels: ['changelog'],
+        },
+        aiUsed: false,
+        fallbackReasons: ['AI disabled by --no-ai'],
+      })),
+      finalizeChangelogUpdate: jest.fn(() => ({
+        llm: {
+          new_section_markdown: 'generated section',
+          insert_after_anchor: '## [Unreleased]',
+          pr_title: 'docs(changelog): 1.2.3',
+          pr_body: 'body',
+          labels: ['changelog'],
+        },
+        updated: 'updated changelog',
+      })),
+      writeChangelog: jest.fn(),
+      ensureGithubTokenRequired: jest.fn(),
+      createPR: jest.fn(),
+    };
+
+    await executeChangelogRun({
+      cli: { ...cli, dryRunJsonReport: true, noAi: true },
+      appConfig,
+      log,
+      deps,
+    });
+
+    expect(JSON.parse(log.mock.calls[1][0])).toEqual({
+      provider: 'openai',
+      model: 'mock-openai',
+      aiUsed: false,
+      fallbackReasons: ['AI disabled by --no-ai'],
+    });
   });
 });

--- a/tests/lib/cli-args.test.ts
+++ b/tests/lib/cli-args.test.ts
@@ -30,6 +30,10 @@ describe('cli-args', () => {
     expect(out.instructions).toBeUndefined();
     expect(out.instructionsFile).toBeUndefined();
     expect(out.dryRun).toBe(false);
+    expect(out.dryRunJsonReport).toBe(false);
+    expect(out.failOnLlmError).toBe(false);
+    expect(out.requireProvider).toBe(false);
+    expect(out.noAi).toBe(false);
   });
 
   test('parses explicit flags', async () => {
@@ -57,6 +61,10 @@ describe('cli-args', () => {
       '--instructions-file',
       '.github/changelog-instructions.md',
       '--dry-run',
+      '--dry-run-json-report',
+      '--fail-on-llm-error',
+      '--require-provider',
+      '--ai',
     ]);
 
     expect(out.repoPath).toBe('/tmp/repo');
@@ -70,6 +78,16 @@ describe('cli-args', () => {
     expect(out.instructions).toBe('Use concise bullets.');
     expect(out.instructionsFile).toBe('.github/changelog-instructions.md');
     expect(out.dryRun).toBe(true);
+    expect(out.dryRunJsonReport).toBe(true);
+    expect(out.failOnLlmError).toBe(true);
+    expect(out.requireProvider).toBe(true);
+    expect(out.noAi).toBe(false);
+  });
+
+  test('parses --no-ai as deterministic mode', async () => {
+    const out = await parseCliArgs(['node', 'cli', '--no-ai']);
+
+    expect(out.noAi).toBe(true);
   });
 
   test('parses gemini provider', async () => {
@@ -92,6 +110,8 @@ describe('cli-args', () => {
           provider: PROVIDER_GEMINI,
           language: 'nl',
           instructionsFile: '.github/changelog-instructions.md',
+          dryRunJsonReport: true,
+          noAi: true,
         }),
         'utf8',
       );
@@ -101,6 +121,8 @@ describe('cli-args', () => {
       expect(out.provider).toBe(PROVIDER_GEMINI);
       expect(out.language).toBe('nl');
       expect(out.instructionsFile).toBe('.github/changelog-instructions.md');
+      expect(out.dryRunJsonReport).toBe(true);
+      expect(out.noAi).toBe(true);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
@@ -116,6 +138,7 @@ describe('cli-args', () => {
           provider: PROVIDER_GEMINI,
           language: 'nl',
           dryRun: true,
+          noAi: true,
         }),
         'utf8',
       );
@@ -131,6 +154,7 @@ describe('cli-args', () => {
           '--language',
           'en',
           '--no-dry-run',
+          '--ai',
         ],
         { cwd },
       );
@@ -138,8 +162,15 @@ describe('cli-args', () => {
       expect(out.provider).toBe(PROVIDER_ANTHROPIC);
       expect(out.language).toBe('en');
       expect(out.dryRun).toBe(false);
+      expect(out.noAi).toBe(false);
     } finally {
       rmSync(cwd, { recursive: true, force: true });
     }
+  });
+
+  test('rejects contradictory no-ai and require-provider flags', async () => {
+    await expect(
+      parseCliArgs(['node', 'cli', '--no-ai', '--require-provider']),
+    ).rejects.toThrow('--no-ai cannot be combined with --require-provider');
   });
 });

--- a/tests/lib/prompt-build-llm-input.test.ts
+++ b/tests/lib/prompt-build-llm-input.test.ts
@@ -32,3 +32,39 @@ test('buildLLMInput truncates changelog to preview limit and maps fields', () =>
   expect(input.customInstructions).toBe('Write concise user-facing bullets.');
   expect(input.changelogPreview.length).toBe(CHANGELOG_PREVIEW_LIMIT);
 });
+
+test('buildLLMInput matches provider prompt golden shape', () => {
+  expect(
+    buildLLMInput({
+      repo: 'octo/repo',
+      version: '1.2.3',
+      date: '2026-06-07',
+      releaseTag: 'v1.2.3',
+      prevTag: 'v1.2.2',
+      releaseBody: "## What's Changed\n- Add JSON report",
+      gitLog: 'abcdef1 feat: add dry-run JSON report (#123)',
+      mergedPRs: '- #123 Add JSON report @nyaomaru',
+      changelog: '# Changelog\n\n## [Unreleased]\n',
+      language: 'en',
+      customInstructions: 'Keep bullets concise.',
+    }),
+  ).toMatchInlineSnapshot(`
+{
+  "changelogPreview": "# Changelog
+
+## [Unreleased]
+",
+  "customInstructions": "Keep bullets concise.",
+  "date": "2026-06-07",
+  "gitLog": "abcdef1 feat: add dry-run JSON report (#123)",
+  "language": "en",
+  "mergedPRs": "- #123 Add JSON report @nyaomaru",
+  "prevTag": "v1.2.2",
+  "releaseBody": "## What's Changed
+- Add JSON report",
+  "releaseTag": "v1.2.3",
+  "repo": "octo/repo",
+  "version": "1.2.3",
+}
+`);
+});

--- a/tests/providers/gemini.test.ts
+++ b/tests/providers/gemini.test.ts
@@ -124,4 +124,56 @@ describe('GeminiProvider', () => {
     );
     expect(requestBody.generationConfig.responseFormat).toBeUndefined();
   });
+
+  test('throws classification parse errors when requested', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: JSON.stringify({ Added: 'not-array' }) }],
+              },
+            },
+          ],
+        }),
+    });
+
+    const provider = new GeminiProvider({
+      apiKey: 'gemini-test',
+      model: 'gemini-test-model',
+    });
+
+    await expect(
+      provider.classifyTitles(['Add Gemini support'], { throwOnError: true }),
+    ).rejects.toThrow('Gemini classify output did not match schema');
+  });
+
+  test('keeps deterministic classification fallback by default', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: JSON.stringify({ Added: 'not-array' }) }],
+              },
+            },
+          ],
+        }),
+    });
+
+    const provider = new GeminiProvider({
+      apiKey: 'gemini-test',
+      model: 'gemini-test-model',
+    });
+
+    await expect(
+      provider.classifyTitles(['Add Gemini support']),
+    ).resolves.toEqual({
+      Chore: ['Add Gemini support'],
+    });
+  });
 });

--- a/tests/utils/dry-run-diagnostics.test.ts
+++ b/tests/utils/dry-run-diagnostics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from '@jest/globals';
-import { formatDryRunDiagnostics } from '@/utils/dry-run-diagnostics.js';
+import {
+  formatDryRunDiagnostics,
+  formatDryRunJsonReport,
+} from '@/utils/dry-run-diagnostics.js';
 
 describe('formatDryRunDiagnostics', () => {
   test('renders provider usage when AI was used', () => {
@@ -29,5 +32,23 @@ describe('formatDryRunDiagnostics', () => {
         fallbackReasons: ['Missing API key for provider: openai'],
       }),
     ).toContain('Fallback reasons: Missing API key for provider: openai');
+  });
+
+  test('renders machine-readable JSON report', () => {
+    expect(
+      JSON.parse(
+        formatDryRunJsonReport({
+          providerName: 'openai',
+          modelName: 'gpt-4o-mini',
+          aiUsed: false,
+          fallbackReasons: ['AI disabled by --no-ai'],
+        }),
+      ),
+    ).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      aiUsed: false,
+      fallbackReasons: ['AI disabled by --no-ai'],
+    });
   });
 });

--- a/tests/utils/llm-output.test.ts
+++ b/tests/utils/llm-output.test.ts
@@ -7,6 +7,7 @@ await jest.unstable_mockModule('@/utils/classify.js', () => ({
 }));
 
 const { buildChangelogLlmOutput } = await import('@/utils/llm-output.js');
+const { LlmError } = await import('@/lib/errors.js');
 
 const mockProvider = {
   name: 'openai',
@@ -48,6 +49,9 @@ function buildBaseParams(overrides = {}) {
     hasProviderKey: false,
     token: undefined,
     githubApiBase: 'https://api.github.com',
+    noAi: false,
+    requireProvider: false,
+    failOnLlmError: false,
     ...overrides,
   };
 }
@@ -88,6 +92,43 @@ describe('llm-output', () => {
     );
     expect(result.llm.new_section_markdown).toContain('### Added');
     expect(result.llm.new_section_markdown).toContain('- Add feature');
+  });
+
+  test('no-ai uses release notes without provider classification', async () => {
+    const classifyTitles = jest.fn(async () => {
+      throw new Error('classification should be skipped');
+    });
+
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: "## What's Changed\n- Add feature\n",
+        provider: { ...mockProvider, classifyTitles },
+        hasProviderKey: true,
+        noAi: true,
+      }),
+    );
+
+    expect(classifyTitles).not.toHaveBeenCalled();
+    expect(result.aiUsed).toBe(false);
+    expect(result.fallbackReasons).toEqual(
+      expect.arrayContaining([
+        'AI disabled by --no-ai',
+        'Used GitHub Release Notes as the source (no model call)',
+      ]),
+    );
+    expect(result.llm.pr_body).toContain('Generated without LLM');
+    expect(result.llm.new_section_markdown).toContain('- Add feature');
+  });
+
+  test('require-provider fails when the selected provider has no key', async () => {
+    await expect(
+      buildChangelogLlmOutput(
+        buildBaseParams({
+          releaseBody: "## What's Changed\n- Add feature\n",
+          requireProvider: true,
+        }),
+      ),
+    ).rejects.toThrow(LlmError);
   });
 
   test('preserves custom release-note sections when no items are parsed', async () => {
@@ -200,5 +241,63 @@ describe('llm-output', () => {
       'Used GitHub Release Notes as the source (no model call)',
     );
     expect(result.llm.new_section_markdown).toContain('日本語の出力');
+  });
+
+  test('falls back when mocked provider generation fails by default', async () => {
+    const generate = jest.fn(async () => {
+      throw new Error('provider down');
+    });
+    const providerWithFailure = { ...mockProvider, generate };
+
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        commitList: [{ sha: 'abcdef1', subject: 'fix: patch bug' }],
+        provider: providerWithFailure,
+        providerConfig: { apiKey: 'sk-test', model: 'mock-model' },
+        hasProviderKey: true,
+      }),
+    );
+
+    expect(generate).toHaveBeenCalled();
+    expect(result.aiUsed).toBe(false);
+    expect(result.fallbackReasons.join('\n')).toContain(
+      'LLM generation failed: provider down',
+    );
+    expect(result.llm.new_section_markdown).toContain('### Fixed');
+  });
+
+  test('fail-on-llm-error throws when mocked provider generation fails', async () => {
+    const generate = jest.fn(async () => {
+      throw new Error('provider down');
+    });
+    const providerWithFailure = { ...mockProvider, generate };
+
+    await expect(
+      buildChangelogLlmOutput(
+        buildBaseParams({
+          provider: providerWithFailure,
+          providerConfig: { apiKey: 'sk-test', model: 'mock-model' },
+          hasProviderKey: true,
+          failOnLlmError: true,
+        }),
+      ),
+    ).rejects.toThrow(LlmError);
+  });
+
+  test('fail-on-llm-error throws when mocked release-note classification fails', async () => {
+    const classifyTitles = jest.fn(async () => {
+      throw new Error('classifier down');
+    });
+
+    await expect(
+      buildChangelogLlmOutput(
+        buildBaseParams({
+          releaseBody: "## What's Changed\n- Add feature\n",
+          provider: { ...mockProvider, classifyTitles },
+          hasProviderKey: true,
+          failOnLlmError: true,
+        }),
+      ),
+    ).rejects.toThrow(LlmError);
   });
 });

--- a/tests/utils/output-json-schema.test.ts
+++ b/tests/utils/output-json-schema.test.ts
@@ -28,4 +28,43 @@ describe('output-json-schema', () => {
     expect(props.pr_body).toEqual({ type: 'string' });
     expect(props.labels).toEqual({ type: 'array', items: { type: 'string' } });
   });
+
+  test('matches provider-facing schema golden shape', () => {
+    expect(outputSchema).toMatchInlineSnapshot(`
+{
+  "properties": {
+    "compare_link_line": {
+      "type": "string",
+    },
+    "insert_after_anchor": {
+      "type": "string",
+    },
+    "labels": {
+      "items": {
+        "type": "string",
+      },
+      "type": "array",
+    },
+    "new_section_markdown": {
+      "type": "string",
+    },
+    "pr_body": {
+      "type": "string",
+    },
+    "pr_title": {
+      "type": "string",
+    },
+    "unreleased_compare_update": {
+      "type": "string",
+    },
+  },
+  "required": [
+    "new_section_markdown",
+    "pr_title",
+    "pr_body",
+  ],
+  "type": "object",
+}
+`);
+  });
 });


### PR DESCRIPTION
## Summary

Add reliability controls.

<!-- A brief summary of the changes -->

## Description

- Add v0.5 reliability controls for AI behavior: `--no-ai`, `--require-provider`, and `--fail-on-llm-error`
- Add `--dry-run-json-report` with provider/model/AI usage/fallback reason diagnostics
- Make release-note classification respect deterministic and strict-failure modes
- Strengthen mocked provider integration coverage and add prompt/schema golden tests
- Document the new CLI/config/GitHub Action options

<!-- A detailed explanation of the changes, including why they are needed -->
