### PR TITLE
fix: enable WHY extraction in release workflow

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -17,6 +17,9 @@ jobs:
       provider: openai
       release_tag: ${{ github.event.release.tag_name }}
       release_body: ${{ github.event.release.body }}
+      why: 'true'
+      why_confidence: medium
+      why_label: Why
       dry_run: 'false'
     secrets:
       REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Enable WHY extraction in release workflow.

<!-- A brief summary of the changes -->

## Description

- Enable WHY extraction explicitly.
- Use `medium` confidence.
- Render generated notes with the `Why` label.

<!-- A detailed explanation of the changes, including why they are needed -->
