### PR TITLE
refactor(why): extract PR reference parsing

### DIFF
--- a/src/utils/why-pr-reference.ts
+++ b/src/utils/why-pr-reference.ts
@@ -1,0 +1,147 @@
+const PULL_URL_PR_NUMBER_RE =
+  /\b(?<pullUrl>https?:\/\/[^\s)]+\/pull\/(?<prNumber>\d+)\b)/gi;
+const PULL_LINK_SUFFIX_RE =
+  /(?:\bin\s+)?\[#\d+\]\((?<pullUrl>https?:\/\/[^\s)]+\/pull\/(?<prNumber>\d+)\b[^)]*)\)(?:\s+by\s+@[\w-]+(?:\[bot\])?)?\s*$/i;
+const PR_SUFFIX_RE =
+  /(?:\bin\s+#(?<plain>\d+)\b|\(#(?<parenthesized>\d+)\))\s*$/i;
+const AUTHOR_RE = /\sby\s@(?<author>[\w-]+(?:\[bot\])?)/i;
+
+/** Repository identity used to validate authoritative pull request links. */
+export type WhyRepository = {
+  /** Repository owner or organization. */
+  owner: string;
+  /** Repository name. */
+  repo: string;
+  /** Web hostname used by pull request links. */
+  host?: string;
+};
+
+type OwningPrReference = {
+  /** Pull request number parsed from the authoritative reference. */
+  prNumber: number;
+  /** Start offset of metadata to remove from the rendered item text. */
+  startIndex: number;
+  /** End offset of metadata to remove from the rendered item text. */
+  endIndex: number;
+};
+
+/** Parsed changelog bullet associated with an authoritative pull request. */
+export type ParsedWhyBullet = {
+  /** Pull request that owns the changelog bullet. */
+  prNumber: number;
+  /** Bullet text with only generated PR metadata removed. */
+  itemText: string;
+  /** Optional author attached to generated release-note bullets. */
+  author?: string;
+};
+
+function cleanItemText(line: string, reference: OwningPrReference): string {
+  const lineWithoutOwningReference = `${line.slice(0, reference.startIndex)}${line.slice(reference.endIndex)}`;
+  return lineWithoutOwningReference
+    .replace(/^[-*]\s+/, '')
+    .replace(/\sby\s@[\w-]+(?:\[bot\])?/gi, '')
+    .replace(/\s*(?:in\s+)?\[#\d+\]\(\)/gi, '')
+    .trim();
+}
+
+function isCurrentRepositoryPullUrl(
+  pullUrl: string | undefined,
+  repository: WhyRepository,
+): boolean {
+  if (!pullUrl) return false;
+  try {
+    const parsedUrl = new URL(pullUrl);
+    const expectedHost = repository.host ?? 'github.com';
+    if (parsedUrl.hostname.toLowerCase() !== expectedHost.toLowerCase()) {
+      return false;
+    }
+    const pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
+    return (
+      pathSegments[0]?.toLowerCase() === repository.owner.toLowerCase() &&
+      pathSegments[1]?.toLowerCase() === repository.repo.toLowerCase() &&
+      pathSegments[2]?.toLowerCase() === 'pull' &&
+      /^\d+$/.test(pathSegments[3] ?? '')
+    );
+  } catch {
+    return false;
+  }
+}
+
+function parsePrNumber(rawNumber: string | undefined): number | null {
+  if (!rawNumber) return null;
+  const prNumber = Number.parseInt(rawNumber, 10);
+  return Number.isSafeInteger(prNumber) ? prNumber : null;
+}
+
+function extractOwningPrReference(
+  line: string,
+  repository: WhyRepository,
+): OwningPrReference | null {
+  const suffixMatch = PR_SUFFIX_RE.exec(line);
+  const suffixPrNumber = parsePrNumber(
+    suffixMatch?.groups?.plain ?? suffixMatch?.groups?.parenthesized,
+  );
+  if (suffixMatch && suffixPrNumber) {
+    return {
+      prNumber: suffixPrNumber,
+      startIndex: suffixMatch.index,
+      endIndex: suffixMatch.index + suffixMatch[0].length,
+    };
+  }
+
+  const linkedSuffixMatch = PULL_LINK_SUFFIX_RE.exec(line);
+  const linkedSuffixPrNumber = parsePrNumber(
+    linkedSuffixMatch?.groups?.prNumber,
+  );
+  if (
+    linkedSuffixMatch &&
+    linkedSuffixPrNumber &&
+    isCurrentRepositoryPullUrl(linkedSuffixMatch.groups?.pullUrl, repository)
+  ) {
+    return {
+      prNumber: linkedSuffixPrNumber,
+      startIndex: linkedSuffixMatch.index,
+      endIndex: linkedSuffixMatch.index + linkedSuffixMatch[0].length,
+    };
+  }
+
+  const pullUrlMatches = Array.from(
+    line.matchAll(PULL_URL_PR_NUMBER_RE),
+  ).filter((match) =>
+    isCurrentRepositoryPullUrl(match.groups?.pullUrl, repository),
+  );
+  const lastPullUrlMatch = pullUrlMatches[pullUrlMatches.length - 1];
+  const pullUrlPrNumber = parsePrNumber(lastPullUrlMatch?.groups?.prNumber);
+  if (lastPullUrlMatch && pullUrlPrNumber) {
+    return {
+      prNumber: pullUrlPrNumber,
+      startIndex: lastPullUrlMatch.index,
+      endIndex: lastPullUrlMatch.index + lastPullUrlMatch[0].length,
+    };
+  }
+
+  // WHY: A prose `#123` may identify an issue or a different PR. Fetch only
+  // references whose position or URL establishes that they own this bullet.
+  return null;
+}
+
+/**
+ * Parse a changelog bullet with an authoritative current-repository PR reference.
+ * WHY: PR identification and metadata removal share the same accepted forms so
+ * prose issue references and external PR URLs remain part of the item text.
+ * @param line Markdown bullet line.
+ * @param repository Repository whose pull requests are authoritative.
+ * @returns Parsed bullet or null when no authoritative PR target exists.
+ */
+export function parseWhyBullet(
+  line: string,
+  repository: WhyRepository,
+): ParsedWhyBullet | null {
+  const reference = extractOwningPrReference(line, repository);
+  if (!reference) return null;
+  return {
+    prNumber: reference.prNumber,
+    itemText: cleanItemText(line, reference),
+    author: AUTHOR_RE.exec(line)?.groups?.author,
+  };
+}

--- a/src/utils/why-targets.ts
+++ b/src/utils/why-targets.ts
@@ -5,161 +5,17 @@ import {
   splitMarkdownSections,
 } from '@/utils/markdown-sections.js';
 import { isDependencyUpdateTitle } from '@/utils/dependency-update.js';
+import {
+  parseWhyBullet,
+  type WhyRepository,
+} from '@/utils/why-pr-reference.js';
 
-const PULL_URL_PR_NUMBER_RE =
-  /\b(?<pullUrl>https?:\/\/[^\s)]+\/pull\/(?<prNumber>\d+)\b)/gi;
-const PULL_LINK_SUFFIX_RE =
-  /(?:\bin\s+)?\[#\d+\]\((?<pullUrl>https?:\/\/[^\s)]+\/pull\/(?<prNumber>\d+)\b[^)]*)\)(?:\s+by\s+@[\w-]+(?:\[bot\])?)?\s*$/i;
-const PR_SUFFIX_RE =
-  /(?:\bin\s+#(?<plain>\d+)\b|\(#(?<parenthesized>\d+)\))\s*$/i;
-const AUTHOR_RE = /\sby\s@(?<author>[\w-]+(?:\[bot\])?)/i;
+export type { WhyRepository } from '@/utils/why-pr-reference.js';
+
 const BOT_AUTHOR_RE = /(?:\[bot\]|bot$|renovate|dependabot)/i;
-
-/** Repository identity used to validate authoritative pull request links. */
-export type WhyRepository = {
-  /** Repository owner or organization. */
-  owner: string;
-  /** Repository name. */
-  repo: string;
-  /** Web hostname used by pull request links. */
-  host?: string;
-};
-
-type OwningPrReference = {
-  /** Pull request number parsed from the authoritative reference. */
-  prNumber: number;
-  /** Start offset of metadata to remove from the rendered item text. */
-  startIndex: number;
-  /** End offset of metadata to remove from the rendered item text. */
-  endIndex: number;
-};
-
-type ParsedWhyBullet = {
-  /** Pull request that owns the changelog bullet. */
-  prNumber: number;
-  /** Bullet text with only generated PR metadata removed. */
-  itemText: string;
-  /** Optional author attached to generated release-note bullets. */
-  author?: string;
-};
 
 function whyNoteKey(sectionTitle: string, prNumber: number): string {
   return `${sectionTitle}\0${prNumber}`;
-}
-
-function cleanItemText(line: string, reference: OwningPrReference): string {
-  const lineWithoutOwningReference = `${line.slice(0, reference.startIndex)}${line.slice(reference.endIndex)}`;
-  return lineWithoutOwningReference
-    .replace(/^[-*]\s+/, '')
-    .replace(/\sby\s@[\w-]+(?:\[bot\])?/gi, '')
-    .replace(/\s*(?:in\s+)?\[#\d+\]\(\)/gi, '')
-    .trim();
-}
-
-function isCurrentRepositoryPullUrl(
-  pullUrl: string | undefined,
-  repository: WhyRepository,
-): boolean {
-  if (!pullUrl) return false;
-  try {
-    const parsedUrl = new URL(pullUrl);
-    const expectedHost = repository.host ?? 'github.com';
-    if (parsedUrl.hostname.toLowerCase() !== expectedHost.toLowerCase()) {
-      return false;
-    }
-    const pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
-    return (
-      pathSegments[0]?.toLowerCase() === repository.owner.toLowerCase() &&
-      pathSegments[1]?.toLowerCase() === repository.repo.toLowerCase() &&
-      pathSegments[2]?.toLowerCase() === 'pull' &&
-      /^\d+$/.test(pathSegments[3] ?? '')
-    );
-  } catch {
-    return false;
-  }
-}
-
-function extractOwningPrReference(
-  line: string,
-  repository: WhyRepository,
-): OwningPrReference | null {
-  const suffixMatch = PR_SUFFIX_RE.exec(line);
-  const suffixPrNumber = parsePrNumber(
-    suffixMatch?.groups?.plain ?? suffixMatch?.groups?.parenthesized,
-  );
-  if (suffixMatch && suffixPrNumber) {
-    return {
-      prNumber: suffixPrNumber,
-      startIndex: suffixMatch.index,
-      endIndex: suffixMatch.index + suffixMatch[0].length,
-    };
-  }
-
-  const linkedSuffixMatch = PULL_LINK_SUFFIX_RE.exec(line);
-  const linkedSuffixPrNumber = parsePrNumber(
-    linkedSuffixMatch?.groups?.prNumber,
-  );
-  if (
-    linkedSuffixMatch &&
-    linkedSuffixPrNumber &&
-    isCurrentRepositoryPullUrl(linkedSuffixMatch.groups?.pullUrl, repository)
-  ) {
-    return {
-      prNumber: linkedSuffixPrNumber,
-      startIndex: linkedSuffixMatch.index,
-      endIndex: linkedSuffixMatch.index + linkedSuffixMatch[0].length,
-    };
-  }
-
-  const pullUrlMatches = Array.from(
-    line.matchAll(PULL_URL_PR_NUMBER_RE),
-  ).filter((match) =>
-    isCurrentRepositoryPullUrl(match.groups?.pullUrl, repository),
-  );
-  const lastPullUrlMatch = pullUrlMatches[pullUrlMatches.length - 1];
-  const pullUrlPrNumber = parsePrNumber(lastPullUrlMatch?.groups?.prNumber);
-  if (lastPullUrlMatch && pullUrlPrNumber) {
-    return {
-      prNumber: pullUrlPrNumber,
-      startIndex: lastPullUrlMatch.index,
-      endIndex: lastPullUrlMatch.index + lastPullUrlMatch[0].length,
-    };
-  }
-
-  // WHY: A prose `#123` may identify an issue or a different PR. Fetch only
-  // references whose position or URL establishes that they own this bullet.
-  return null;
-}
-
-function parsePrNumber(rawNumber: string | undefined): number | null {
-  if (!rawNumber) return null;
-  const prNumber = Number.parseInt(rawNumber, 10);
-  return Number.isSafeInteger(prNumber) ? prNumber : null;
-}
-
-function extractAuthor(line: string): string | undefined {
-  return AUTHOR_RE.exec(line)?.groups?.author;
-}
-
-/**
- * Parse a changelog bullet with an authoritative PR reference.
- * WHY: PR identification and metadata removal must share the same accepted
- * forms so prose issue references remain part of the model context.
- * @param line Markdown bullet line.
- * @param repository Repository whose pull requests are authoritative.
- * @returns Parsed bullet or null when no authoritative PR target exists.
- */
-function parseWhyBullet(
-  line: string,
-  repository: WhyRepository,
-): ParsedWhyBullet | null {
-  const reference = extractOwningPrReference(line, repository);
-  if (!reference) return null;
-  return {
-    prNumber: reference.prNumber,
-    itemText: cleanItemText(line, reference),
-    author: extractAuthor(line),
-  };
 }
 
 /**

--- a/tests/utils/why-pr-reference.test.ts
+++ b/tests/utils/why-pr-reference.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { parseWhyBullet } from '@/utils/why-pr-reference.js';
+
+const repository = { owner: 'octo', repo: 'repo' };
+
+describe('why-pr-reference', () => {
+  test('parses and removes current-repository PR metadata', () => {
+    const parsed = parseWhyBullet(
+      '- Fix release lookup by @alice in [#42](https://github.com/octo/repo/pull/42)',
+      repository,
+    );
+
+    expect(parsed).toEqual({
+      prNumber: 42,
+      itemText: 'Fix release lookup',
+      author: 'alice',
+    });
+  });
+
+  test.each(['- Fix release lookup in #42', '- Fix release lookup (#42)'])(
+    'accepts generated numeric suffixes: %s',
+    (line) => {
+      expect(parseWhyBullet(line, repository)).toMatchObject({
+        prNumber: 42,
+        itemText: 'Fix release lookup',
+      });
+    },
+  );
+
+  test('rejects an external repository PR link', () => {
+    const parsed = parseWhyBullet(
+      '- Sync behavior with https://github.com/upstream/repo/pull/42',
+      repository,
+    );
+
+    expect(parsed).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Extract PR reference parsing.

<!-- A brief summary of the changes -->

## Description

- Separate PR ownership and repository URL validation from WHY target processing.
- Move suffix parsing and changelog item cleanup into `why-pr-reference`.
- Preserve the existing `WhyRepository` export.

<!-- A detailed explanation of the changes, including why they are needed -->
