### PR TITLE
fix: report prompt customization diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ pnpm dlx @nyaomaru/changelog-bot \
 Custom instructions are additive: the bot still enforces its JSON schema,
 deduplication, and factuality rules.
 
+Instruction files are read as UTF-8. Inline and file instructions are combined
+with a blank line between them, then capped at 16,000 characters. Empty
+instruction files and unreadable instruction files are ignored. Dry-run
+diagnostics report whether prompt customization was requested, resolved, and
+actually applied. Customization only affects provider full generation; with
+`--no-ai`, missing provider keys, or provider generation fallback, the
+deterministic release-note/fallback output is produced without applying the
+custom instructions.
+
 ### Use a config file
 
 Create `changelog-bot.config.json` in the directory where you run the CLI:

--- a/src/lib/changelog-run.ts
+++ b/src/lib/changelog-run.ts
@@ -23,7 +23,7 @@ import {
   resolveRunCredentials,
 } from '@/lib/release-context.js';
 import { finalizeChangelogUpdate } from '@/lib/changelog-update.js';
-import { resolveCustomInstructions } from '@/lib/customization.js';
+import { resolveCustomInstructionsWithDiagnostics } from '@/lib/customization.js';
 import {
   formatDryRunDiagnostics,
   formatDryRunJsonReport,
@@ -40,6 +40,40 @@ import { runWhyExtraction } from '@/lib/why-extraction.js';
 
 /** Logger used by the CLI runner for user-visible output. */
 export type ChangelogRunLogger = (message: string) => void;
+
+type PromptCustomizationReasonInput = {
+  /** Whether customization was passed by inline text or file path. */
+  requested: boolean;
+  /** Whether any usable customization text remained after resolution. */
+  resolved: boolean;
+  /** Whether provider calls were disabled for this run. */
+  noAi: boolean;
+  /** Whether the selected provider has a configured API key. */
+  hasProviderKey: boolean;
+  /** Whether changelog generation used a provider successfully. */
+  aiUsed: boolean;
+};
+
+/**
+ * Explain whether prompt customization affected the generated changelog.
+ * @param input Customization resolution and provider execution state.
+ * @returns Stable dry-run reason text.
+ */
+function getPromptCustomizationReason(
+  input: PromptCustomizationReasonInput,
+): string {
+  if (!input.requested) return 'not requested';
+  if (!input.resolved) return 'no usable instructions after normalization';
+  if (input.noAi)
+    return 'not applied because --no-ai skips provider generation';
+  if (!input.hasProviderKey) {
+    return 'not applied because provider API key is missing';
+  }
+  if (!input.aiUsed) {
+    return 'not applied because provider generation did not complete';
+  }
+  return 'applied to provider full generation';
+}
 
 /** Replaceable dependencies for testing the orchestration without shell/network I/O. */
 export type ChangelogRunDependencies = {
@@ -69,8 +103,8 @@ export type ChangelogRunDependencies = {
   fetchPRDetails: typeof fetchPRDetails;
   /** Fetch the open pull request associated with the current branch. */
   fetchPullRequestsForBranch: typeof fetchPullRequestsForBranch;
-  /** Resolve inline and file-based changelog customization instructions. */
-  resolveCustomInstructions: typeof resolveCustomInstructions;
+  /** Resolve changelog customization instructions with diagnostics. */
+  resolveCustomInstructionsWithDiagnostics: typeof resolveCustomInstructionsWithDiagnostics;
   /** Build commit SHA -> PR number mappings. */
   buildPrMapBySha: typeof buildPrMapBySha;
   /** Build normalized title -> PR number mappings. */
@@ -105,7 +139,7 @@ const defaultDependencies: ChangelogRunDependencies = {
   fetchReleaseBody,
   fetchPRDetails,
   fetchPullRequestsForBranch,
-  resolveCustomInstructions,
+  resolveCustomInstructionsWithDiagnostics,
   buildPrMapBySha,
   buildTitleToPr,
   getProviderRuntimeConfig,
@@ -214,11 +248,13 @@ export async function executeChangelogRun(params: {
     apiPrMap,
   });
   const titleToPr = deps.buildTitleToPr(commitList, prs, prMapBySha);
-  const customInstructions = deps.resolveCustomInstructions({
-    instructions: cli.instructions,
-    instructionsFile: cli.instructionsFile,
-    repoPath,
-  });
+  const customInstructionsResolution =
+    deps.resolveCustomInstructionsWithDiagnostics({
+      instructions: cli.instructions,
+      instructionsFile: cli.instructionsFile,
+      repoPath,
+    });
+  const customInstructions = customInstructionsResolution.instructions;
   const providerConfig = deps.getProviderRuntimeConfig(
     appConfig,
     provider.name,
@@ -295,6 +331,17 @@ export async function executeChangelogRun(params: {
       modelName: providerConfig.model,
       aiUsed: llmOutput.aiUsed || whyOutput.diagnostics.aiUsed,
       fallbackReasons: llmOutput.fallbackReasons,
+      promptCustomization: {
+        ...customInstructionsResolution.diagnostics,
+        applied: Boolean(customInstructions && llmOutput.aiUsed && !cli.noAi),
+        reason: getPromptCustomizationReason({
+          requested: customInstructionsResolution.diagnostics.requested,
+          resolved: customInstructionsResolution.diagnostics.resolved,
+          noAi: cli.noAi,
+          hasProviderKey,
+          aiUsed: llmOutput.aiUsed,
+        }),
+      },
       why: whyOutput.diagnostics,
     };
     log(

--- a/src/lib/customization.ts
+++ b/src/lib/customization.ts
@@ -1,7 +1,15 @@
 import { readFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 
-const CUSTOM_INSTRUCTIONS_ENCODING = 'utf8';
+export const CUSTOM_INSTRUCTIONS_ENCODING = 'utf8';
+export const CUSTOM_INSTRUCTIONS_MAX_CHARS = 16_000;
+
+/** Resolved status for the optional customization instructions file. */
+export type CustomInstructionsFileStatus =
+  | 'not_provided'
+  | 'loaded'
+  | 'empty'
+  | 'read_failed';
 
 /** Inputs used to resolve optional changelog customization instructions. */
 export type ResolveCustomInstructionsInput = {
@@ -11,6 +19,38 @@ export type ResolveCustomInstructionsInput = {
   instructionsFile?: string;
   /** Repository root used to resolve relative instruction file paths. */
   repoPath: string;
+};
+
+/** Diagnostics for resolved prompt customization instructions. */
+export type CustomInstructionsDiagnostics = {
+  /** Whether inline or file customization was requested. */
+  requested: boolean;
+  /** Whether non-empty customization text is available for the prompt. */
+  resolved: boolean;
+  /** Instruction sources that contributed text after normalization. */
+  sources: Array<'inline' | 'file'>;
+  /** Character count after normalization and optional truncation. */
+  chars: number;
+  /** Maximum combined instruction length accepted by the prompt builder. */
+  maxChars: number;
+  /** Encoding used when reading the instructions file. */
+  encoding: typeof CUSTOM_INSTRUCTIONS_ENCODING;
+  /** Whether combined instructions were truncated to maxChars. */
+  truncated: boolean;
+  /** File status after reading and normalization. */
+  fileStatus: CustomInstructionsFileStatus;
+  /** Original instructions file path, when provided. */
+  filePath?: string;
+  /** Non-fatal file read error, when the file could not be read. */
+  fileError?: string;
+};
+
+/** Resolved prompt customization and its diagnostics. */
+export type CustomInstructionsResolution = {
+  /** Combined instructions, or undefined when none were usable. */
+  instructions?: string;
+  /** Resolution diagnostics for dry-run reporting. */
+  diagnostics: CustomInstructionsDiagnostics;
 };
 
 function normalizeInstructionText(text?: string): string | undefined {
@@ -29,23 +69,82 @@ function readInstructionsFile(
 }
 
 /**
+ * Resolve inline and file-based customization instructions with diagnostics.
+ * Empty file content and read failures are ignored so optional customization
+ * never blocks deterministic release generation.
+ * @param input Inline instructions, optional file path, and repository path.
+ * @returns Combined instructions plus diagnostics describing the resolution.
+ */
+export function resolveCustomInstructionsWithDiagnostics(
+  input: ResolveCustomInstructionsInput,
+): CustomInstructionsResolution {
+  const inlineInstructions = normalizeInstructionText(input.instructions);
+  let fileInstructions: string | undefined;
+  let fileStatus: CustomInstructionsFileStatus = input.instructionsFile
+    ? 'empty'
+    : 'not_provided';
+  let fileError: string | undefined;
+
+  if (input.instructionsFile) {
+    try {
+      fileInstructions = normalizeInstructionText(
+        readInstructionsFile(input.repoPath, input.instructionsFile),
+      );
+      fileStatus = fileInstructions ? 'loaded' : 'empty';
+    } catch (error) {
+      fileStatus = 'read_failed';
+      fileError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const instructionParts = [
+    inlineInstructions
+      ? { source: 'inline' as const, text: inlineInstructions }
+      : null,
+    fileInstructions
+      ? { source: 'file' as const, text: fileInstructions }
+      : null,
+  ].filter(
+    (
+      instructionPart,
+    ): instructionPart is { source: 'inline' | 'file'; text: string } =>
+      Boolean(instructionPart),
+  );
+
+  const combinedInstructions = instructionParts
+    .map((instructionPart) => instructionPart.text)
+    .join('\n\n');
+  const truncated = combinedInstructions.length > CUSTOM_INSTRUCTIONS_MAX_CHARS;
+  const instructions = combinedInstructions
+    ? combinedInstructions.slice(0, CUSTOM_INSTRUCTIONS_MAX_CHARS)
+    : undefined;
+
+  return {
+    instructions,
+    diagnostics: {
+      requested: Boolean(input.instructions || input.instructionsFile),
+      resolved: Boolean(instructions),
+      sources: instructionParts.map(
+        (instructionPart) => instructionPart.source,
+      ),
+      chars: instructions?.length ?? 0,
+      maxChars: CUSTOM_INSTRUCTIONS_MAX_CHARS,
+      encoding: CUSTOM_INSTRUCTIONS_ENCODING,
+      truncated,
+      fileStatus,
+      ...(input.instructionsFile ? { filePath: input.instructionsFile } : {}),
+      ...(fileError ? { fileError } : {}),
+    },
+  };
+}
+
+/**
  * Resolve inline and file-based customization instructions into one prompt block.
  * @param input Inline instructions, optional file path, and repository path.
- * @returns Combined instructions, or undefined when none were provided.
+ * @returns Combined instructions, or undefined when none were usable.
  */
 export function resolveCustomInstructions(
   input: ResolveCustomInstructionsInput,
 ): string | undefined {
-  const instructionParts = [
-    normalizeInstructionText(input.instructions),
-    input.instructionsFile
-      ? normalizeInstructionText(
-          readInstructionsFile(input.repoPath, input.instructionsFile),
-        )
-      : undefined,
-  ].filter((instructionPart): instructionPart is string =>
-    Boolean(instructionPart),
-  );
-
-  return instructionParts.length ? instructionParts.join('\n\n') : undefined;
+  return resolveCustomInstructionsWithDiagnostics(input).instructions;
 }

--- a/src/utils/dry-run-diagnostics.ts
+++ b/src/utils/dry-run-diagnostics.ts
@@ -1,5 +1,15 @@
 import type { ProviderName } from '@/types/llm.js';
 import type { WhyDiagnostics } from '@/types/why.js';
+import type { CustomInstructionsDiagnostics } from '@/lib/customization.js';
+
+/** Prompt customization state shown in dry-run diagnostics. */
+export type DryRunPromptCustomizationDiagnostics =
+  CustomInstructionsDiagnostics & {
+    /** Whether customization affected provider full-generation output. */
+    applied: boolean;
+    /** Human-readable explanation of the applied state. */
+    reason: string;
+  };
 
 /** Inputs required to render dry-run execution diagnostics. */
 export type DryRunDiagnosticsInput = {
@@ -11,6 +21,8 @@ export type DryRunDiagnosticsInput = {
   aiUsed: boolean;
   /** Reasons explaining fallback behavior when provider usage was skipped or failed. */
   fallbackReasons: string[];
+  /** Prompt customization diagnostics when customization is in scope. */
+  promptCustomization?: DryRunPromptCustomizationDiagnostics;
   /** WHY extraction diagnostics when requested. */
   why?: WhyDiagnostics;
 };
@@ -25,6 +37,8 @@ export type DryRunJsonReport = {
   aiUsed: boolean;
   /** Reasons explaining fallback behavior when provider usage was skipped or failed. */
   fallbackReasons: string[];
+  /** Prompt customization diagnostics when customization is in scope. */
+  promptCustomization?: DryRunPromptCustomizationDiagnostics;
   /** WHY extraction diagnostics when requested. */
   why?: WhyDiagnostics;
 };
@@ -45,6 +59,26 @@ export function formatDryRunDiagnostics(input: DryRunDiagnosticsInput): string {
     `AI used: ${input.aiUsed ? 'true' : 'false'}`,
     `Fallback reasons: ${fallbackReasonText}`,
   ];
+
+  if (input.promptCustomization) {
+    const customization = input.promptCustomization;
+    const sourceText = customization.sources.length
+      ? customization.sources.join('+')
+      : 'none';
+    const fileText =
+      customization.fileStatus === 'not_provided'
+        ? 'not_provided'
+        : `${customization.fileStatus} (${customization.filePath ?? 'unknown'})`;
+    const truncatedText = customization.truncated ? ', truncated=true' : '';
+    lines.push(
+      `Prompt customization: requested=${customization.requested}, applied=${customization.applied}, sources=${sourceText}, chars=${customization.chars}/${customization.maxChars}, encoding=${customization.encoding}${truncatedText}`,
+      `Prompt customization file: ${fileText}`,
+      `Prompt customization reason: ${customization.reason}`,
+    );
+    if (customization.fileError) {
+      lines.push(`Prompt customization file error: ${customization.fileError}`);
+    }
+  }
 
   if (input.why?.enabled) {
     const whyFallbackReasonText = input.why.fallbackReasons.length
@@ -74,6 +108,9 @@ export function formatDryRunJsonReport(input: DryRunDiagnosticsInput): string {
     model: input.modelName,
     aiUsed: input.aiUsed,
     fallbackReasons: input.fallbackReasons,
+    ...(input.promptCustomization
+      ? { promptCustomization: input.promptCustomization }
+      : {}),
     ...(input.why?.enabled ? { why: input.why } : {}),
   };
 

--- a/tests/lib/changelog-run.test.ts
+++ b/tests/lib/changelog-run.test.ts
@@ -52,6 +52,35 @@ const provider = {
   extractWhyNotes: jest.fn(),
 };
 
+const unresolvedCustomization = {
+  instructions: undefined,
+  diagnostics: {
+    requested: false,
+    resolved: false,
+    sources: [],
+    chars: 0,
+    maxChars: 16000,
+    encoding: 'utf8',
+    truncated: false,
+    fileStatus: 'not_provided',
+  },
+};
+
+const resolvedCustomization = {
+  instructions: 'combined instructions',
+  diagnostics: {
+    requested: true,
+    resolved: true,
+    sources: ['inline', 'file'],
+    chars: 21,
+    maxChars: 16000,
+    encoding: 'utf8',
+    truncated: false,
+    fileStatus: 'loaded',
+    filePath: '.github/changelog-instructions.md',
+  },
+};
+
 describe('executeChangelogRun', () => {
   test('uses current branch PR metadata for HEAD releases', async () => {
     const log = jest.fn();
@@ -96,7 +125,9 @@ describe('executeChangelogRun', () => {
       fetchPullRequestsForBranch: jest.fn(async () => [branchPullRequest]),
       mapCommitsToPrs: jest.fn(async () => ({})),
       fetchReleaseBody: jest.fn(async () => ''),
-      resolveCustomInstructions: jest.fn(() => undefined),
+      resolveCustomInstructionsWithDiagnostics: jest.fn(
+        () => unresolvedCustomization,
+      ),
       buildPrMapBySha: jest.fn(() => ({ abcdef1234567890: [138] })),
       buildTitleToPr: jest.fn(() => ({ 'add WHY extraction': 138 })),
       getProviderRuntimeConfig: jest.fn(() => appConfig.providers.openai),
@@ -163,7 +194,9 @@ describe('executeChangelogRun', () => {
       })),
       mapCommitsToPrs: jest.fn(async () => ({})),
       fetchReleaseBody: jest.fn(),
-      resolveCustomInstructions: jest.fn(() => 'combined instructions'),
+      resolveCustomInstructionsWithDiagnostics: jest.fn(
+        () => resolvedCustomization,
+      ),
       buildPrMapBySha: jest.fn(() => ({ abcdef1234567890: [123] })),
       buildTitleToPr: jest.fn(() => ({ 'add CLI dry run': 123 })),
       getProviderRuntimeConfig: jest.fn(() => appConfig.providers.openai),
@@ -226,6 +259,9 @@ describe('executeChangelogRun', () => {
         'Model: mock-openai',
         'AI used: false',
         'Fallback reasons: none',
+        'Prompt customization: requested=true, applied=false, sources=inline+file, chars=21/16000, encoding=utf8',
+        'Prompt customization file: loaded (.github/changelog-instructions.md)',
+        'Prompt customization reason: not applied because provider API key is missing',
       ].join('\n'),
     );
     expect(log).toHaveBeenNthCalledWith(3, '');
@@ -256,7 +292,9 @@ describe('executeChangelogRun', () => {
       })),
       mapCommitsToPrs: jest.fn(async () => ({})),
       fetchReleaseBody: jest.fn(),
-      resolveCustomInstructions: jest.fn(() => undefined),
+      resolveCustomInstructionsWithDiagnostics: jest.fn(
+        () => unresolvedCustomization,
+      ),
       buildPrMapBySha: jest.fn(() => ({})),
       buildTitleToPr: jest.fn(() => ({})),
       getProviderRuntimeConfig: jest.fn(() => appConfig.providers.openai),
@@ -298,6 +336,11 @@ describe('executeChangelogRun', () => {
       model: 'mock-openai',
       aiUsed: false,
       fallbackReasons: ['AI disabled by --no-ai'],
+      promptCustomization: {
+        ...unresolvedCustomization.diagnostics,
+        applied: false,
+        reason: 'not requested',
+      },
     });
   });
 });

--- a/tests/lib/customization.test.ts
+++ b/tests/lib/customization.test.ts
@@ -2,7 +2,12 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, test } from '@jest/globals';
-import { resolveCustomInstructions } from '@/lib/customization.js';
+import {
+  CUSTOM_INSTRUCTIONS_ENCODING,
+  CUSTOM_INSTRUCTIONS_MAX_CHARS,
+  resolveCustomInstructions,
+  resolveCustomInstructionsWithDiagnostics,
+} from '@/lib/customization.js';
 
 describe('resolveCustomInstructions', () => {
   test('combines inline and file instructions', () => {
@@ -28,5 +33,54 @@ describe('resolveCustomInstructions', () => {
 
   test('returns undefined when no instructions are provided', () => {
     expect(resolveCustomInstructions({ repoPath: '.' })).toBeUndefined();
+  });
+
+  test('ignores empty instructions files', () => {
+    const repoPath = mkdtempSync(join(tmpdir(), 'changelog-bot-'));
+    try {
+      writeFileSync(join(repoPath, 'instructions.md'), ' \n ', 'utf8');
+
+      const result = resolveCustomInstructionsWithDiagnostics({
+        instructionsFile: 'instructions.md',
+        repoPath,
+      });
+
+      expect(result.instructions).toBeUndefined();
+      expect(result.diagnostics).toMatchObject({
+        requested: true,
+        resolved: false,
+        fileStatus: 'empty',
+        encoding: CUSTOM_INSTRUCTIONS_ENCODING,
+      });
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true });
+    }
+  });
+
+  test('ignores unreadable instructions files', () => {
+    const result = resolveCustomInstructionsWithDiagnostics({
+      instructionsFile: 'missing.md',
+      repoPath: '.',
+    });
+
+    expect(result.instructions).toBeUndefined();
+    expect(result.diagnostics).toMatchObject({
+      requested: true,
+      resolved: false,
+      fileStatus: 'read_failed',
+      filePath: 'missing.md',
+    });
+    expect(result.diagnostics.fileError).toContain('missing.md');
+  });
+
+  test('truncates combined instructions to the documented maximum size', () => {
+    const result = resolveCustomInstructionsWithDiagnostics({
+      instructions: 'x'.repeat(CUSTOM_INSTRUCTIONS_MAX_CHARS + 1),
+      repoPath: '.',
+    });
+
+    expect(result.instructions).toHaveLength(CUSTOM_INSTRUCTIONS_MAX_CHARS);
+    expect(result.diagnostics.chars).toBe(CUSTOM_INSTRUCTIONS_MAX_CHARS);
+    expect(result.diagnostics.truncated).toBe(true);
   });
 });

--- a/tests/utils/dry-run-diagnostics.test.ts
+++ b/tests/utils/dry-run-diagnostics.test.ts
@@ -30,8 +30,23 @@ describe('formatDryRunDiagnostics', () => {
         modelName: 'gpt-4o-mini',
         aiUsed: false,
         fallbackReasons: ['Missing API key for provider: openai'],
+        promptCustomization: {
+          requested: true,
+          resolved: true,
+          applied: false,
+          reason: 'not applied because provider API key is missing',
+          sources: ['file'],
+          chars: 24,
+          maxChars: 16000,
+          encoding: 'utf8',
+          truncated: false,
+          fileStatus: 'loaded',
+          filePath: '.github/changelog-instructions.md',
+        },
       }),
-    ).toContain('Fallback reasons: Missing API key for provider: openai');
+    ).toContain(
+      'Prompt customization: requested=true, applied=false, sources=file, chars=24/16000, encoding=utf8',
+    );
   });
 
   test('renders machine-readable JSON report', () => {
@@ -42,6 +57,18 @@ describe('formatDryRunDiagnostics', () => {
           modelName: 'gpt-4o-mini',
           aiUsed: false,
           fallbackReasons: ['AI disabled by --no-ai'],
+          promptCustomization: {
+            requested: true,
+            resolved: true,
+            applied: false,
+            reason: 'not applied because --no-ai skips provider generation',
+            sources: ['inline'],
+            chars: 19,
+            maxChars: 16000,
+            encoding: 'utf8',
+            truncated: false,
+            fileStatus: 'not_provided',
+          },
         }),
       ),
     ).toEqual({
@@ -49,6 +76,18 @@ describe('formatDryRunDiagnostics', () => {
       model: 'gpt-4o-mini',
       aiUsed: false,
       fallbackReasons: ['AI disabled by --no-ai'],
+      promptCustomization: {
+        requested: true,
+        resolved: true,
+        applied: false,
+        reason: 'not applied because --no-ai skips provider generation',
+        sources: ['inline'],
+        chars: 19,
+        maxChars: 16000,
+        encoding: 'utf8',
+        truncated: false,
+        fileStatus: 'not_provided',
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary

Report prompt customization diagnostics.

<!-- A brief summary of the changes -->

## Description

- Add dry-run diagnostics for prompt customization resolution/application
- Ignore empty or unreadable instructions files instead of failing
- Cap combined custom instructions at 16,000 UTF-8 characters

<!-- A detailed explanation of the changes, including why they are needed -->
