### PR TITLE
refactor: simplify changelog run and why utilities

### DIFF
--- a/src/lib/changelog-run.ts
+++ b/src/lib/changelog-run.ts
@@ -156,14 +156,23 @@ const defaultDependencies: ChangelogRunDependencies = {
 };
 
 type ResolvePullRequestsByShaParams = {
+  /** Replaceable workflow dependencies for git/GitHub lookups. */
   deps: ChangelogRunDependencies;
+  /** Repository owner or organization. */
   owner: string;
+  /** Repository name. */
   repo: string;
+  /** Release ref selected for this run. */
   releaseRef: string;
+  /** Local repository path used for git commands. */
   repoPath: string;
+  /** GitHub API token, when available. */
   token?: string;
+  /** GitHub or GHES API base URL. */
   githubApiBase: string;
+  /** Commits included in the release range. */
   commitList: CommitLite[];
+  /** Commit SHAs included in the release range. */
   commitShas: string[];
 };
 
@@ -218,11 +227,17 @@ async function resolvePullRequestsBySha({
 }
 
 async function resolveReleaseBody(params: {
+  /** Parsed CLI options. */
   cli: CliOptions;
+  /** Replaceable workflow dependencies for GitHub lookups. */
   deps: ChangelogRunDependencies;
+  /** Repository owner or organization. */
   owner: string;
+  /** Repository name. */
   repo: string;
+  /** GitHub API token, when available. */
   token?: string;
+  /** GitHub or GHES API base URL. */
   githubApiBase: string;
 }): Promise<string> {
   if (params.cli.releaseBody) return params.cli.releaseBody;
@@ -238,18 +253,29 @@ async function resolveReleaseBody(params: {
 }
 
 function writeDryRunOutput(params: {
+  /** Parsed CLI options. */
   cli: CliOptions;
+  /** Logger used for user-visible output. */
   log: ChangelogRunLogger;
+  /** Selected provider name. */
   providerName: ProviderName;
+  /** Selected model name. */
   modelName: string;
+  /** Whether changelog generation used a provider successfully. */
   changelogAiUsed: boolean;
+  /** Changelog-generation fallback reasons. */
   fallbackReasons: string[];
+  /** Resolved prompt customization and diagnostics. */
   customInstructionsResolution: ReturnType<
     typeof resolveCustomInstructionsWithDiagnostics
   >;
+  /** Usable prompt customization text, if any. */
   customInstructions?: string;
+  /** Whether the selected provider has a configured API key. */
   hasProviderKey: boolean;
+  /** WHY extraction diagnostics. */
   whyDiagnostics: WhyDiagnostics;
+  /** Changelog content produced by the run. */
   updated: string;
 }): void {
   const {

--- a/src/lib/changelog-run.ts
+++ b/src/lib/changelog-run.ts
@@ -37,6 +37,10 @@ import { buildPrMapBySha, buildTitleToPr } from '@/utils/pr-mapping.js';
 import type { AppConfig } from '@/types/config.js';
 import type { CliOptions } from '@/schema/cli.js';
 import { runWhyExtraction } from '@/lib/why-extraction.js';
+import type { CommitLite } from '@/types/commit.js';
+import type { PullRef } from '@/types/github.js';
+import type { ProviderName } from '@/types/llm.js';
+import type { WhyDiagnostics } from '@/types/why.js';
 
 /** Logger used by the CLI runner for user-visible output. */
 export type ChangelogRunLogger = (message: string) => void;
@@ -151,6 +155,145 @@ const defaultDependencies: ChangelogRunDependencies = {
   createPR,
 };
 
+type ResolvePullRequestsByShaParams = {
+  deps: ChangelogRunDependencies;
+  owner: string;
+  repo: string;
+  releaseRef: string;
+  repoPath: string;
+  token?: string;
+  githubApiBase: string;
+  commitList: CommitLite[];
+  commitShas: string[];
+};
+
+async function resolvePullRequestsBySha({
+  deps,
+  owner,
+  repo,
+  releaseRef,
+  repoPath,
+  token,
+  githubApiBase,
+  commitList,
+  commitShas,
+}: ResolvePullRequestsByShaParams): Promise<Record<string, PullRef[]>> {
+  const branchName =
+    releaseRef === 'HEAD' ? deps.currentBranch(repoPath) : null;
+  const branchPullRequests = branchName
+    ? await deps.fetchPullRequestsForBranch(
+        owner,
+        repo,
+        branchName,
+        token,
+        githubApiBase,
+      )
+    : [];
+  const remotePrNumber =
+    branchName && branchPullRequests.length === 0
+      ? deps.tryFindPullRequestNumberForBranch(branchName, repoPath)
+      : null;
+  const oldestCommit = commitList[commitList.length - 1];
+  const remotePullRequest =
+    remotePrNumber && oldestCommit
+      ? {
+          number: remotePrNumber,
+          title: oldestCommit.subject,
+          url: `https://github.com/${owner}/${repo}/pull/${remotePrNumber}`,
+        }
+      : null;
+  const authoritativePullRequests = branchPullRequests.length
+    ? branchPullRequests
+    : remotePullRequest
+      ? [remotePullRequest]
+      : [];
+
+  if (authoritativePullRequests.length) {
+    return Object.fromEntries(
+      commitShas.map((commitSha) => [commitSha, authoritativePullRequests]),
+    );
+  }
+
+  return deps.mapCommitsToPrs(owner, repo, commitShas, token, githubApiBase);
+}
+
+async function resolveReleaseBody(params: {
+  cli: CliOptions;
+  deps: ChangelogRunDependencies;
+  owner: string;
+  repo: string;
+  token?: string;
+  githubApiBase: string;
+}): Promise<string> {
+  if (params.cli.releaseBody) return params.cli.releaseBody;
+  if (!params.cli.releaseTag) return '';
+
+  return params.deps.fetchReleaseBody(
+    params.owner,
+    params.repo,
+    params.cli.releaseTag,
+    params.token,
+    params.githubApiBase,
+  );
+}
+
+function writeDryRunOutput(params: {
+  cli: CliOptions;
+  log: ChangelogRunLogger;
+  providerName: ProviderName;
+  modelName: string;
+  changelogAiUsed: boolean;
+  fallbackReasons: string[];
+  customInstructionsResolution: ReturnType<
+    typeof resolveCustomInstructionsWithDiagnostics
+  >;
+  customInstructions?: string;
+  hasProviderKey: boolean;
+  whyDiagnostics: WhyDiagnostics;
+  updated: string;
+}): void {
+  const {
+    cli,
+    log,
+    providerName,
+    modelName,
+    changelogAiUsed,
+    fallbackReasons,
+    customInstructionsResolution,
+    customInstructions,
+    hasProviderKey,
+    whyDiagnostics,
+    updated,
+  } = params;
+
+  log('==== DRY RUN (no PR) ====');
+  const diagnosticsInput = {
+    providerName,
+    modelName,
+    aiUsed: changelogAiUsed || whyDiagnostics.aiUsed,
+    fallbackReasons,
+    promptCustomization: {
+      ...customInstructionsResolution.diagnostics,
+      applied: Boolean(customInstructions && changelogAiUsed && !cli.noAi),
+      reason: getPromptCustomizationReason({
+        requested: customInstructionsResolution.diagnostics.requested,
+        resolved: customInstructionsResolution.diagnostics.resolved,
+        noAi: cli.noAi,
+        hasProviderKey,
+        aiUsed: changelogAiUsed,
+      }),
+    },
+    why: whyDiagnostics,
+  };
+  log(
+    cli.dryRunJsonReport
+      ? formatDryRunJsonReport(diagnosticsInput)
+      : formatDryRunDiagnostics(diagnosticsInput),
+  );
+  log('');
+  log(updated);
+}
+
 /**
  * Execute the changelog generation workflow for already-parsed CLI options.
  * WHY: Keeping orchestration here makes `runCli` small and gives tests a seam
@@ -189,57 +332,25 @@ export async function executeChangelogRun(params: {
     repo,
     appConfig,
   );
-  const branchName =
-    releaseRef === 'HEAD' ? deps.currentBranch(repoPath) : null;
-  const branchPullRequests = branchName
-    ? await deps.fetchPullRequestsForBranch(
-        owner,
-        repo,
-        branchName,
-        token,
-        appConfig.github.apiBase,
-      )
-    : [];
-  const remotePrNumber =
-    branchName && branchPullRequests.length === 0
-      ? deps.tryFindPullRequestNumberForBranch(branchName, repoPath)
-      : null;
-  const oldestCommit = commitList[commitList.length - 1];
-  const remotePullRequest =
-    remotePrNumber && oldestCommit
-      ? {
-          number: remotePrNumber,
-          title: oldestCommit.subject,
-          url: `https://github.com/${owner}/${repo}/pull/${remotePrNumber}`,
-        }
-      : null;
-  const authoritativePullRequests = branchPullRequests.length
-    ? branchPullRequests
-    : remotePullRequest
-      ? [remotePullRequest]
-      : [];
-  const apiPrMap = authoritativePullRequests.length
-    ? Object.fromEntries(
-        commitShas.map((commitSha) => [commitSha, authoritativePullRequests]),
-      )
-    : await deps.mapCommitsToPrs(
-        owner,
-        repo,
-        commitShas,
-        token,
-        appConfig.github.apiBase,
-      );
-
-  let releaseBody = cli.releaseBody || '';
-  if (!releaseBody && cli.releaseTag) {
-    releaseBody = await deps.fetchReleaseBody(
-      owner,
-      repo,
-      cli.releaseTag,
-      token,
-      appConfig.github.apiBase,
-    );
-  }
+  const apiPrMap = await resolvePullRequestsBySha({
+    deps,
+    owner,
+    repo,
+    releaseRef,
+    repoPath,
+    token,
+    githubApiBase: appConfig.github.apiBase,
+    commitList,
+    commitShas,
+  });
+  const releaseBody = await resolveReleaseBody({
+    cli,
+    deps,
+    owner,
+    repo,
+    token,
+    githubApiBase: appConfig.github.apiBase,
+  });
 
   const prMapBySha = deps.buildPrMapBySha({
     commitList,
@@ -325,32 +436,19 @@ export async function executeChangelogRun(params: {
   }
 
   if (cli.dryRun) {
-    log('==== DRY RUN (no PR) ====');
-    const diagnosticsInput = {
+    writeDryRunOutput({
+      cli,
+      log,
       providerName: provider.name,
       modelName: providerConfig.model,
-      aiUsed: llmOutput.aiUsed || whyOutput.diagnostics.aiUsed,
+      changelogAiUsed: llmOutput.aiUsed,
       fallbackReasons: llmOutput.fallbackReasons,
-      promptCustomization: {
-        ...customInstructionsResolution.diagnostics,
-        applied: Boolean(customInstructions && llmOutput.aiUsed && !cli.noAi),
-        reason: getPromptCustomizationReason({
-          requested: customInstructionsResolution.diagnostics.requested,
-          resolved: customInstructionsResolution.diagnostics.resolved,
-          noAi: cli.noAi,
-          hasProviderKey,
-          aiUsed: llmOutput.aiUsed,
-        }),
-      },
-      why: whyOutput.diagnostics,
-    };
-    log(
-      cli.dryRunJsonReport
-        ? formatDryRunJsonReport(diagnosticsInput)
-        : formatDryRunDiagnostics(diagnosticsInput),
-    );
-    log('');
-    log(updated);
+      customInstructionsResolution,
+      customInstructions,
+      hasProviderKey,
+      whyDiagnostics: whyOutput.diagnostics,
+      updated,
+    });
     return;
   }
 

--- a/src/utils/why-preprocess.ts
+++ b/src/utils/why-preprocess.ts
@@ -14,6 +14,7 @@ import type {
   WhyTrustBucket,
 } from '@/types/why.js';
 import { isDependencyUpdateTitle } from '@/utils/dependency-update.js';
+import { escapeRegExp } from '@/utils/escape.js';
 
 const TARGET_SECTION_LABEL_PATTERN = Array.from(WHY_SECTION_ALIASES.keys())
   .sort((left, right) => right.length - left.length)
@@ -89,10 +90,6 @@ function canonicalTargetSectionName(
   value: string,
 ): WhyCanonicalSectionName | undefined {
   return WHY_SECTION_ALIASES.get(normalizeHeadingName(value));
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function extractTargetSections(body: string): ExtractedSections {

--- a/src/utils/why-targets.ts
+++ b/src/utils/why-targets.ts
@@ -5,6 +5,7 @@ import {
   splitMarkdownSections,
 } from '@/utils/markdown-sections.js';
 import { isDependencyUpdateTitle } from '@/utils/dependency-update.js';
+import { escapeRegExp } from '@/utils/escape.js';
 import {
   parseWhyBullet,
   type WhyRepository,
@@ -13,9 +14,19 @@ import {
 export type { WhyRepository } from '@/utils/why-pr-reference.js';
 
 const BOT_AUTHOR_RE = /(?:\[bot\]|bot$|renovate|dependabot)/i;
+const WHY_ELIGIBLE_SECTION_TITLE_SET = new Set<string>(
+  WHY_ELIGIBLE_SECTION_TITLES,
+);
+const TOP_LEVEL_BULLET_RE = /^[-*]\s+/;
 
 function whyNoteKey(sectionTitle: string, prNumber: number): string {
   return `${sectionTitle}\0${prNumber}`;
+}
+
+function shouldSkipWhyTarget(itemText: string, author?: string): boolean {
+  return Boolean(
+    isDependencyUpdateTitle(itemText) || (author && BOT_AUTHOR_RE.test(author)),
+  );
 }
 
 /**
@@ -34,21 +45,17 @@ export function extractWhyTargets(
   const targets: WhyTarget[] = [];
   let skippedBeforeFetch = 0;
   const document = splitMarkdownSections(sectionMarkdown);
-  const eligibleSectionTitles = new Set<string>(WHY_ELIGIBLE_SECTION_TITLES);
 
   for (const section of document.sections) {
-    if (!eligibleSectionTitles.has(section.name)) continue;
+    if (!WHY_ELIGIBLE_SECTION_TITLE_SET.has(section.name)) continue;
     for (const line of section.lines) {
-      if (!/^[-*]\s+/.test(line)) continue;
+      if (!TOP_LEVEL_BULLET_RE.test(line)) continue;
       const parsedBullet = parseWhyBullet(line, repository);
       if (!parsedBullet) {
         skippedBeforeFetch += 1;
         continue;
       }
-      if (
-        isDependencyUpdateTitle(parsedBullet.itemText) ||
-        (parsedBullet.author && BOT_AUTHOR_RE.test(parsedBullet.author))
-      ) {
+      if (shouldSkipWhyTarget(parsedBullet.itemText, parsedBullet.author)) {
         skippedBeforeFetch += 1;
         continue;
       }
@@ -81,7 +88,6 @@ export function applyWhyNotesToSection(
   if (notes.size === 0) return sectionMarkdown;
 
   const document = splitMarkdownSections(sectionMarkdown);
-  const eligibleSectionTitles = new Set<string>(WHY_ELIGIBLE_SECTION_TITLES);
   const notesBySectionAndPr = new Map(
     Array.from(notes.values()).map((note) => [
       whyNoteKey(note.sectionTitle, note.prNumber),
@@ -90,13 +96,13 @@ export function applyWhyNotesToSection(
   );
 
   for (const section of document.sections) {
-    if (!eligibleSectionTitles.has(section.name)) continue;
+    if (!WHY_ELIGIBLE_SECTION_TITLE_SET.has(section.name)) continue;
 
     const outputLines: string[] = [];
     for (let index = 0; index < section.lines.length; index += 1) {
       const line = section.lines[index] ?? '';
       outputLines.push(line);
-      if (!/^[-*]\s+/.test(line)) continue;
+      if (!TOP_LEVEL_BULLET_RE.test(line)) continue;
       const parsedBullet = parseWhyBullet(line, repository);
       if (!parsedBullet) continue;
       const note = notesBySectionAndPr.get(
@@ -117,8 +123,4 @@ export function applyWhyNotesToSection(
   }
 
   return renderMarkdownSections(document);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }


### PR DESCRIPTION
## Summary

Simplify changelog run and why utilities.

<!-- A brief summary of the changes -->

## Description

- Extract changelog run helper logic for PR mapping, release body resolution, and dry-run output
- Reuse shared `escapeRegExp` in WHY preprocessing/target utilities
- Centralize WHY target eligibility and skip checks without changing behavior

<!-- A detailed explanation of the changes, including why they are needed -->
