### PR TITLE
fix: document exit codes and typed config errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,26 @@ When AI is not used for changelog generation, the PR body is annotated with
 “Generated without LLM. Reason: …”. Title classification uses the provider when
 available; without keys, titles fall back to deterministic local categories.
 
+### Exit codes
+
+Codes `64` and `65` follow the common POSIX `sysexits` convention
+(`EX_USAGE`, `EX_DATAERR`). Codes `66` and `67` stay in the same reserved range
+for changelog-bot-specific provider and schema failures. Code `1` is kept for
+unexpected errors that are not yet classified.
+
+| Code | Meaning                   | Typical cause                                                             |
+| ---- | ------------------------- | ------------------------------------------------------------------------- |
+| `0`  | Success                   | Changelog was generated, or dry-run completed.                            |
+| `1`  | Unexpected error          | Unclassified runtime failure.                                             |
+| `64` | Usage/configuration error | Invalid CLI/config values, missing repo identity, or missing GitHub auth. |
+| `65` | Repository/data error     | Invalid repository state or Git data needed for changelog generation.     |
+| `66` | Provider failure          | LLM generation/classification/WHY extraction failed in strict mode.       |
+| `67` | Output validation failure | Provider output did not match the expected schema after retry.            |
+
+The CLI prints the actionable error message to stderr before exiting. Use
+`--dry-run` to preview without requiring GitHub write authentication, or provide
+`GITHUB_TOKEN` / GitHub App credentials before creating a PR.
+
 ## GitHub Actions integration
 
 The published composite action installs the CLI with `pnpm dlx` and forwards
@@ -539,7 +559,7 @@ Notes
 
 - `Resource not accessible by integration`: add `contents: write` and `pull-requests: write` to the job. For reusable workflows, add them on the calling job.
 - Label warning: the PR was created, but labels were skipped. Add `issues: write` for direct Action/CLI runs, or pass a PAT/GitHub App token with Issues write access to the reusable workflow.
-- `GITHUB_TOKEN is required to create PR`: non-dry-run mode needs `GITHUB_TOKEN`, a PAT, or GitHub App credentials. Dry-run mode does not create a PR.
+- `GitHub authentication is required to create PR`: non-dry-run mode needs `GITHUB_TOKEN`, a PAT, or GitHub App credentials. Dry-run mode does not create a PR.
 - GitHub App JWT or private key errors: use `CHANGELOG_BOT_APP_ID` and `CHANGELOG_BOT_APP_PRIVATE_KEY`, keep the PEM unencrypted, and preserve newlines or use escaped `\n`.
 - Missing release notes or PR titles: use `actions/checkout` with `fetch-depth: 0`, pass `release-body`, and provide GitHub auth for private repositories.
 - AI key missing: the CLI falls back by default. Set the matching provider key, use `require-provider: 'true'` to fail instead, or use `no-ai: 'true'` intentionally.

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -61,6 +61,11 @@ export async function parseCliArgs(
       choices: ['low', 'medium', 'high'] as const,
     })
     .option('why-label', { type: 'string' })
+    .exitProcess(false)
+    .fail((message, error) => {
+      const detail = message || error?.message || 'Invalid CLI arguments';
+      throw new ConfigError(`Invalid CLI arguments: ${detail}`);
+    })
     .strict()
     .parse();
 

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -1,10 +1,12 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+import { z } from 'zod';
 
 import { CliOptionsSchema, type CliOptions } from '@/schema/cli.js';
 import { PROVIDER_NAMES, PROVIDER_OPENAI } from '@/constants/provider.js';
 import type { ProviderName } from '@/types/llm.js';
 import { loadCliConfigFile } from '@/lib/config-file.js';
+import { ConfigError } from '@/lib/errors.js';
 
 type ParseCliArgsOptions = {
   /** Directory used to resolve config files. */
@@ -86,9 +88,16 @@ export async function parseCliArgs(
     whyLabel: parsed['why-label'],
   });
 
-  return CliOptionsSchema.parse({
-    provider: PROVIDER_OPENAI,
-    ...config,
-    ...cliOverrides,
-  });
+  try {
+    return CliOptionsSchema.parse({
+      provider: PROVIDER_OPENAI,
+      ...config,
+      ...cliOverrides,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new ConfigError(`Invalid CLI options: ${z.prettifyError(error)}`);
+    }
+    throw error;
+  }
 }

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -61,7 +61,6 @@ export async function parseCliArgs(
       choices: ['low', 'medium', 'high'] as const,
     })
     .option('why-label', { type: 'string' })
-    .exitProcess(false)
     .fail((message, error) => {
       const detail = message || error?.message || 'Invalid CLI arguments';
       throw new ConfigError(`Invalid CLI arguments: ${detail}`);

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { HEAD_REF } from '@/constants/git.js';
+import { GitError } from '@/lib/errors.js';
 
 /**
  * Pattern that whitelists simple tag or branch names (alphanumeric plus ._-).
@@ -18,7 +19,7 @@ const SAFE_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
  */
 function assertSafeGitRef(value: string, label: string): void {
   if (!SAFE_REF_PATTERN.test(value) && !SAFE_SHA_PATTERN.test(value)) {
-    throw new Error(
+    throw new GitError(
       `Invalid ${label}: "${value}" contains unsupported characters.`,
     );
   }
@@ -31,7 +32,7 @@ function assertSafeGitRef(value: string, label: string): void {
  */
 function assertSafePath(value: string, label: string): void {
   if (value.includes('\0')) {
-    throw new Error(`Invalid ${label}: null byte is not allowed.`);
+    throw new GitError(`Invalid ${label}: null byte is not allowed.`);
   }
 }
 
@@ -42,7 +43,12 @@ function assertSafePath(value: string, label: string): void {
  * @returns Trimmed stdout string.
  */
 export function run(args: readonly string[], cwd?: string): string {
-  return execFileSync('git', args, { encoding: 'utf8', cwd }).trim();
+  try {
+    return execFileSync('git', args, { encoding: 'utf8', cwd }).trim();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new GitError(`Git command failed: git ${args.join(' ')}. ${message}`);
+  }
 }
 /**
  * Run a command and return null on failure instead of throwing.

--- a/src/schema/env.ts
+++ b/src/schema/env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ConfigError } from '@/lib/errors.js';
 
 /**
  * Environment variable validation used by the CLI.
@@ -33,5 +34,9 @@ export function ensureGithubTokenRequired(
   token?: string,
 ): void {
   if (dryRun) return;
-  if (!token) throw new Error('GITHUB_TOKEN is required to create PR.');
+  if (!token) {
+    throw new ConfigError(
+      'GitHub authentication is required to create PR. Set GITHUB_TOKEN or GitHub App credentials.',
+    );
+  }
 }

--- a/src/utils/repository.ts
+++ b/src/utils/repository.ts
@@ -1,3 +1,4 @@
+import { ConfigError } from '@/lib/errors.js';
 import type { AppConfig } from '@/types/config.js';
 
 /**
@@ -9,10 +10,9 @@ import type { AppConfig } from '@/types/config.js';
 export function getRepoFullName(appConfig: AppConfig): string {
   const repoFull = appConfig.github.repoFullName;
   if (!repoFull || !repoFull.includes('/')) {
-    console.error(
+    throw new ConfigError(
       'REPO_FULL_NAME or GITHUB_REPOSITORY is required (owner/repo).',
     );
-    process.exit(1);
   }
   return repoFull;
 }

--- a/tests/lib/cli-args.test.ts
+++ b/tests/lib/cli-args.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { describe, expect, test } from '@jest/globals';
 
 import { parseCliArgs } from '@/lib/cli-args.js';
+import { EXIT_USAGE } from '@/constants/errors.js';
 import {
   DEFAULT_BASE_BRANCH,
   DEFAULT_CHANGELOG_FILE,
@@ -20,6 +21,7 @@ import {
   DEFAULT_WHY_MAX_CHARS_PER_PR,
   DEFAULT_WHY_MAX_PRS,
 } from '@/constants/why.js';
+import { ConfigError, mapErrorToExitCode } from '@/lib/errors.js';
 
 describe('cli-args', () => {
   test('parses defaults with minimal argv', async () => {
@@ -201,5 +203,19 @@ describe('cli-args', () => {
     await expect(
       parseCliArgs(['node', 'cli', '--no-ai', '--require-provider']),
     ).rejects.toThrow('--no-ai cannot be combined with --require-provider');
+
+    await expect(
+      parseCliArgs(['node', 'cli', '--no-ai', '--require-provider']),
+    ).rejects.toBeInstanceOf(ConfigError);
+  });
+
+  test('maps schema-invalid CLI values to usage exit code', async () => {
+    try {
+      await parseCliArgs(['node', 'cli', '--why-max-prs', '-1']);
+      throw new Error('Expected parseCliArgs to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigError);
+      expect(mapErrorToExitCode(error)).toBe(EXIT_USAGE);
+    }
   });
 });

--- a/tests/lib/cli-args.test.ts
+++ b/tests/lib/cli-args.test.ts
@@ -218,4 +218,17 @@ describe('cli-args', () => {
       expect(mapErrorToExitCode(error)).toBe(EXIT_USAGE);
     }
   });
+
+  test.each([
+    ['unknown flag', ['node', 'cli', '--unknown-flag']],
+    ['invalid provider choice', ['node', 'cli', '--provider', 'bogus']],
+  ])('maps yargs %s failures to usage exit code', async (_, argv) => {
+    try {
+      await parseCliArgs(argv);
+      throw new Error('Expected parseCliArgs to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigError);
+      expect(mapErrorToExitCode(error)).toBe(EXIT_USAGE);
+    }
+  });
 });

--- a/tests/lib/git-extract-pr-refs.test.ts
+++ b/tests/lib/git-extract-pr-refs.test.ts
@@ -1,8 +1,12 @@
 // @ts-nocheck
 import { test, expect } from '@jest/globals';
+import { EXIT_DATA } from '@/constants/errors.js';
+import { GitError, mapErrorToExitCode } from '@/lib/errors.js';
 import {
+  commitsInRange,
   extractPrRefsFromText,
   findPullRequestNumberByHeadSha,
+  firstCommit,
 } from '@/lib/git.js';
 
 test('extracts PR numbers and dedupes', () => {
@@ -37,4 +41,25 @@ test('matches a remote branch head to a GitHub pull ref', () => {
       'dc475bc234d283e98cb1b46609c576d2f3430cb2',
     ),
   ).toBe(138);
+});
+
+test('maps unsafe git refs to repository data exit code', () => {
+  expect(() => commitsInRange('bad/ref', 'HEAD', '.')).toThrow(GitError);
+
+  try {
+    commitsInRange('bad/ref', 'HEAD', '.');
+  } catch (error) {
+    expect(error).toBeInstanceOf(GitError);
+    expect(mapErrorToExitCode(error)).toBe(EXIT_DATA);
+  }
+});
+
+test('maps git command failures to repository data exit code', () => {
+  try {
+    firstCommit('/definitely/missing/changelog-bot-repo');
+    throw new Error('Expected firstCommit to fail');
+  } catch (error) {
+    expect(error).toBeInstanceOf(GitError);
+    expect(mapErrorToExitCode(error)).toBe(EXIT_DATA);
+  }
 });

--- a/tests/utils/env.test.ts
+++ b/tests/utils/env.test.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
-import type { Env } from '@/schema/env.js';
+import { EXIT_USAGE } from '@/constants/errors.js';
+import { ConfigError } from '@/lib/errors.js';
+import { ensureGithubTokenRequired, type Env } from '@/schema/env.js';
 import { getEnv } from '@/utils/env.js';
 
 describe('getEnv', () => {
@@ -30,5 +32,28 @@ describe('getEnv', () => {
   test('returns undefined when not in parsed nor process.env', () => {
     const parsed: Env = {} as Env;
     expect(getEnv('GITHUB_APP_ID', parsed)).toBeUndefined();
+  });
+});
+
+describe('ensureGithubTokenRequired', () => {
+  test('allows dry-runs without GitHub authentication', () => {
+    expect(() => ensureGithubTokenRequired(true, undefined)).not.toThrow();
+  });
+
+  test('allows non-dry-runs with resolved GitHub authentication', () => {
+    expect(() => ensureGithubTokenRequired(false, 'token')).not.toThrow();
+  });
+
+  test('throws usage error for non-dry-runs without GitHub authentication', () => {
+    expect(() => ensureGithubTokenRequired(false, undefined)).toThrow(
+      ConfigError,
+    );
+
+    try {
+      ensureGithubTokenRequired(false, undefined);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigError);
+      expect((error as ConfigError).exitCode).toBe(EXIT_USAGE);
+    }
   });
 });

--- a/tests/utils/repository.test.ts
+++ b/tests/utils/repository.test.ts
@@ -1,36 +1,16 @@
-// @ts-nocheck
-import {
-  describe,
-  test,
-  expect,
-  jest,
-  beforeEach,
-  afterEach,
-} from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
+import { EXIT_USAGE } from '@/constants/errors.js';
 import { loadAppConfig } from '@/lib/app-config.js';
+import { ConfigError } from '@/lib/errors.js';
 import { getRepoFullName } from '@/utils/repository.js';
 
 describe('utils/repository.getRepoFullName', () => {
-  const originalExit = process.exit;
-  let errorSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    process.exit = jest.fn() as never;
-  });
-
-  afterEach(() => {
-    errorSpy.mockRestore();
-    process.exit = originalExit;
-  });
-
   test('returns REPO_FULL_NAME when set', () => {
     const config = loadAppConfig({ REPO_FULL_NAME: 'owner/repo' });
 
     const name = getRepoFullName(config);
 
     expect(name).toBe('owner/repo');
-    expect(process.exit).not.toHaveBeenCalled();
   });
 
   test('falls back to GITHUB_REPOSITORY when REPO_FULL_NAME is missing', () => {
@@ -39,20 +19,29 @@ describe('utils/repository.getRepoFullName', () => {
     const name = getRepoFullName(config);
 
     expect(name).toBe('acme/tools');
-    expect(process.exit).not.toHaveBeenCalled();
   });
 
-  test('exits when neither env is set or invalid', () => {
-    getRepoFullName(loadAppConfig({}));
+  test('throws usage error when neither env is set or invalid', () => {
+    expect(() => getRepoFullName(loadAppConfig({}))).toThrow(ConfigError);
 
-    expect(errorSpy).toHaveBeenCalled();
-    expect(process.exit).toHaveBeenCalledWith(1);
+    try {
+      getRepoFullName(loadAppConfig({}));
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigError);
+      expect((error as ConfigError).exitCode).toBe(EXIT_USAGE);
+    }
   });
 
-  test('exits when value does not include a slash', () => {
-    getRepoFullName(loadAppConfig({ REPO_FULL_NAME: 'invalid' }));
+  test('throws usage error when value does not include a slash', () => {
+    expect(() =>
+      getRepoFullName(loadAppConfig({ REPO_FULL_NAME: 'invalid' })),
+    ).toThrow(ConfigError);
 
-    expect(errorSpy).toHaveBeenCalled();
-    expect(process.exit).toHaveBeenCalledWith(1);
+    try {
+      getRepoFullName(loadAppConfig({ REPO_FULL_NAME: 'invalid' }));
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConfigError);
+      expect((error as ConfigError).exitCode).toBe(EXIT_USAGE);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Document exit codes and typed config errors.

<!-- A brief summary of the changes -->

## Description

- Replace direct repository utility exits with typed `ConfigError` failures.
- Treat missing PR creation auth as a usage/configuration error.
- Document CLI exit codes and their `sysexits`-style rationale in README.

<!-- A detailed explanation of the changes, including why they are needed -->
