### PR TITLE
refactor: clarify category tuning rules

### DIFF
--- a/src/utils/category-tune.ts
+++ b/src/utils/category-tune.ts
@@ -1,8 +1,14 @@
 import {
   CONVENTIONAL_PREFIX_RE,
+  FEAT_PREFIX_FLEX_RE,
+  FIX_PREFIX_FLEX_RE,
   REFACTOR_LIKE_RE,
 } from '@/constants/conventional.js';
-import type { CategoryMap } from '@/types/changelog.js';
+import type {
+  BucketName,
+  CategoryMap,
+  CategoryScores,
+} from '@/types/changelog.js';
 import {
   SECTION_ADDED,
   SECTION_CHANGED,
@@ -20,7 +26,111 @@ import {
 } from '@/utils/category-score.js';
 import { isDependencyUpdateTitle } from '@/utils/dependency-update.js';
 import { isBucketName } from '@/utils/is.js';
-import type { BucketName } from '@/types/changelog.js';
+
+const TYPE_INTENT_INDICATORS = [
+  'type',
+  'types',
+  'typing',
+  'type definition',
+  'type definitions',
+  'typedef',
+  'd.ts',
+  'ts type',
+  'option type',
+];
+
+const FIX_INTENT_INDICATORS = [
+  'fix',
+  'correct',
+  'tighten',
+  'narrow',
+  'wrong',
+  'invalid',
+  'incorrect',
+  'mismatch',
+  'bug',
+  'error',
+];
+
+const CHANGE_LIKE_INDICATORS = [
+  'improve',
+  'improvement',
+  'enhance',
+  'enhancement',
+  'optimize',
+  'optimization',
+  'refine',
+  'refinement',
+  'streamline',
+  'simplify',
+  'polish',
+  'rework',
+  'revise',
+  'revamp',
+  'stabilize',
+  'hardening',
+  'harden',
+  'tweak',
+  'adjust',
+  'tune',
+  'tuning',
+  'retune',
+  'fine-tune',
+  'fine tune',
+  'finetune',
+];
+
+const REQUIRED_CATEGORY_BUCKETS = [
+  SECTION_FIXED,
+  SECTION_CHANGED,
+  SECTION_ADDED,
+] as const;
+
+const WEAK_REMAP_BUCKETS = new Set<BucketName>([
+  SECTION_CHORE,
+  SECTION_DOCS,
+  SECTION_TEST,
+]);
+
+function semanticTitleCore(rawTitle: string): string {
+  return rawTitle.toLowerCase().replace(CONVENTIONAL_PREFIX_RE, '').trim();
+}
+
+function collectKnownTitles(
+  items: ReleaseItem[],
+  categories: CategoryMap,
+): string[] {
+  const knownTitles = new Set<string>();
+
+  for (const item of items) {
+    if (item.rawTitle) knownTitles.add(item.rawTitle);
+    knownTitles.add(item.title);
+  }
+
+  for (const list of Object.values(categories)) {
+    if (!Array.isArray(list)) continue;
+    for (const title of list) {
+      knownTitles.add(title);
+    }
+  }
+
+  return Array.from(knownTitles);
+}
+
+function cloneCategoryMap(categories: CategoryMap): CategoryMap {
+  const adjusted: CategoryMap = Object.fromEntries(
+    Object.entries(categories).map(([section, list]) => [
+      section,
+      Array.isArray(list) ? list.slice() : [],
+    ]),
+  );
+
+  for (const section of REQUIRED_CATEGORY_BUCKETS) {
+    if (!adjusted[section]) adjusted[section] = [];
+  }
+
+  return adjusted;
+}
 
 /**
  * Move given titles to a target category on a mutable CategoryMap.
@@ -30,17 +140,106 @@ import type { BucketName } from '@/types/changelog.js';
 function moveTitlesToCategory(
   adjusted: CategoryMap,
   titles: string[],
-  targetCategory: string,
+  targetCategory: BucketName,
 ): void {
   if (!Array.isArray(adjusted[targetCategory])) adjusted[targetCategory] = [];
   const target = adjusted[targetCategory];
   for (const title of titles) {
     for (const list of Object.values(adjusted)) {
       if (!Array.isArray(list)) continue;
-      const idx = list.indexOf(title);
-      if (idx !== -1) list.splice(idx, 1);
+      const titleIndex = list.indexOf(title);
+      if (titleIndex !== -1) list.splice(titleIndex, 1);
     }
     if (!target.includes(title)) target.push(title);
+  }
+}
+
+function collectMatchingTitles(
+  titles: string[],
+  predicate: (title: string) => boolean,
+): string[] {
+  return titles.filter((title) => predicate(title));
+}
+
+function findCategory(
+  categories: CategoryMap,
+  title: string,
+): BucketName | undefined {
+  for (const [section, list] of Object.entries(categories)) {
+    if (Array.isArray(list) && list.includes(title) && isBucketName(section)) {
+      return section;
+    }
+  }
+  return undefined;
+}
+
+function shouldMoveChangeLikeTitle(
+  title: string,
+  currentCategory: BucketName | undefined,
+): boolean {
+  if (
+    !REFACTOR_LIKE_RE.test(title.toLowerCase()) &&
+    !isChangeLikeTitle(title)
+  ) {
+    return false;
+  }
+  if (currentCategory === SECTION_FIXED) return false;
+  if (
+    currentCategory &&
+    currentCategory !== SECTION_CHORE &&
+    currentCategory !== SECTION_ADDED
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function confidentScoredCategory(scores: CategoryScores): BucketName | null {
+  const guidedCategory = bestCategory(scores);
+
+  if (
+    guidedCategory === SECTION_FIXED &&
+    scores[SECTION_FIXED] >= SCORE_THRESHOLDS.fixed
+  ) {
+    return SECTION_FIXED;
+  }
+
+  if (
+    guidedCategory === SECTION_CHANGED &&
+    scores[SECTION_CHANGED] >= SCORE_THRESHOLDS.changed
+  ) {
+    return SECTION_CHANGED;
+  }
+
+  if (
+    guidedCategory === SECTION_ADDED &&
+    scores[SECTION_ADDED] >= SCORE_THRESHOLDS.added
+  ) {
+    return SECTION_ADDED;
+  }
+
+  if (
+    guidedCategory === SECTION_BREAKING_CHANGES &&
+    scores[SECTION_BREAKING_CHANGES] >= SCORE_THRESHOLDS.breaking
+  ) {
+    return SECTION_BREAKING_CHANGES;
+  }
+
+  return null;
+}
+
+function applyScoredWeakBucketRemaps(
+  adjusted: CategoryMap,
+  titles: string[],
+): void {
+  for (const title of titles) {
+    const currentCategory = findCategory(adjusted, title);
+    if (!currentCategory || !WEAK_REMAP_BUCKETS.has(currentCategory)) continue;
+
+    const targetCategory = confidentScoredCategory(scoreCategories(title));
+    if (!targetCategory) continue;
+
+    moveTitlesToCategory(adjusted, [title], targetCategory);
   }
 }
 
@@ -54,40 +253,14 @@ function moveTitlesToCategory(
  */
 export function isImplicitFixTitle(rawTitle: string): boolean {
   if (!rawTitle) return false;
-  const lower = rawTitle.toLowerCase();
+  const core = semanticTitleCore(rawTitle);
 
-  // Strip conventional prefix to focus on the semantic core.
-  const core = lower.replace(CONVENTIONAL_PREFIX_RE, '').trim();
-
-  // Keywords indicating typing/contract corrections.
-  const typeIndicators = [
-    'type',
-    'types',
-    'typing',
-    'type definition',
-    'type definitions',
-    'typedef',
-    'd.ts',
-    'ts type',
-    'option type',
-  ];
-
-  // Verbs/adjectives that suggest a correctness fix rather than pure refactor.
-  const fixIndicators = [
-    'fix',
-    'correct',
-    'tighten',
-    'narrow',
-    'wrong',
-    'invalid',
-    'incorrect',
-    'mismatch',
-    'bug',
-    'error',
-  ];
-
-  const mentionsType = typeIndicators.some((keyword) => core.includes(keyword));
-  const impliesFix = fixIndicators.some((keyword) => core.includes(keyword));
+  const mentionsType = TYPE_INTENT_INDICATORS.some((keyword) =>
+    core.includes(keyword),
+  );
+  const impliesFix = FIX_INTENT_INDICATORS.some((keyword) =>
+    core.includes(keyword),
+  );
 
   // If the core mentions typing/contract and implies a correction, treat as Fixed.
   if (mentionsType && impliesFix) return true;
@@ -110,40 +283,10 @@ export function isImplicitFixTitle(rawTitle: string): boolean {
  */
 export function isChangeLikeTitle(rawTitle: string): boolean {
   if (!rawTitle) return false;
-  const lower = rawTitle.toLowerCase();
-  const core = lower.replace(CONVENTIONAL_PREFIX_RE, '').trim();
+  const core = semanticTitleCore(rawTitle);
 
-  // Keywords indicating general improvements/behavior changes (domain-agnostic).
-  // Avoid overly broad terms like "update/change" to reduce false positives.
-  const changeIndicators = [
-    'improve',
-    'improvement',
-    'enhance',
-    'enhancement',
-    'optimize',
-    'optimization',
-    'refine',
-    'refinement',
-    'streamline',
-    'simplify',
-    'polish',
-    'rework',
-    'revise',
-    'revamp',
-    'stabilize',
-    'hardening',
-    'harden',
-    'tweak',
-    'adjust',
-    'tune',
-    'tuning',
-    'retune',
-    'fine-tune',
-    'fine tune',
-    'finetune',
-  ];
-
-  return changeIndicators.some((kw) => core.includes(kw));
+  // WHY: Avoid broad terms like "update/change" to reduce false positives.
+  return CHANGE_LIKE_INDICATORS.some((keyword) => core.includes(keyword));
 }
 
 /**
@@ -158,38 +301,14 @@ export function tuneCategoriesByTitle(
 ): CategoryMap {
   if (!items.length) return categories;
 
-  // Build lookup for quick access to the raw/original title used by the classifier output.
-  const knownTitles = new Set<string>();
-  for (const item of items) {
-    if (item.rawTitle) knownTitles.add(item.rawTitle);
-    knownTitles.add(item.title);
-  }
-  // Also add all titles from the classifier output (categories) to ensure remapping works for modified titles.
-  for (const list of Object.values(categories)) {
-    if (Array.isArray(list)) {
-      for (const title of list) {
-        knownTitles.add(title);
-      }
-    }
-  }
-  // Ensure Fixed/Changed buckets exist on a deep-copied map so we don't mutate inputs.
-  const adjusted: CategoryMap = Object.fromEntries(
-    Object.entries(categories).map(([section, list]) => [
-      section,
-      Array.isArray(list) ? list.slice() : [],
-    ]),
-  );
-  if (!adjusted[SECTION_FIXED]) adjusted[SECTION_FIXED] = [];
-  if (!adjusted[SECTION_CHANGED]) adjusted[SECTION_CHANGED] = [];
-  if (!adjusted[SECTION_ADDED]) adjusted[SECTION_ADDED] = [];
-
-  const allKnownTitles = Array.from(knownTitles);
+  const adjusted = cloneCategoryMap(categories);
+  const allKnownTitles = collectKnownTitles(items, categories);
 
   // Rule: Dependency-only updates should remain in Chore to avoid noise in Changed.
-  const dependencyUpdates: string[] = [];
-  for (const title of allKnownTitles) {
-    if (isDependencyUpdateTitle(title)) dependencyUpdates.push(title);
-  }
+  const dependencyUpdates = collectMatchingTitles(
+    allKnownTitles,
+    isDependencyUpdateTitle,
+  );
   if (dependencyUpdates.length)
     moveTitlesToCategory(adjusted, dependencyUpdates, SECTION_CHORE);
   const dependencyUpdateSet = new Set(dependencyUpdates);
@@ -197,104 +316,37 @@ export function tuneCategoriesByTitle(
     (title) => !dependencyUpdateSet.has(title),
   );
 
-  // Collect titles that should be moved.
-  const toMove: string[] = [];
-  for (const title of nonDependencyTitles) {
-    if (isImplicitFixTitle(title)) toMove.push(title);
-  }
+  const implicitFixes = collectMatchingTitles(
+    nonDependencyTitles,
+    isImplicitFixTitle,
+  );
+  if (implicitFixes.length)
+    moveTitlesToCategory(adjusted, implicitFixes, SECTION_FIXED);
 
-  // Remove from any existing buckets and add to Fixed, ensuring uniqueness.
-  if (toMove.length) moveTitlesToCategory(adjusted, toMove, SECTION_FIXED);
-
-  // Rule: Conventional `fix:` prefix should map to Fixed (guard against LLM misclassifying as Chore).
-  // Match conventional fix prefixes including optional scope and optional breaking '!'
-  // Examples: fix: msg, fix!: msg, fix(scope): msg, fix(scope)!: msg
-  const FIX_PREFIX_RE = /^fix(?:!:|(?:\([^)]*\))?!?:)/i;
-  const conventionalFixes: string[] = [];
-  for (const title of nonDependencyTitles) {
-    if (FIX_PREFIX_RE.test(title)) conventionalFixes.push(title);
-  }
+  // Rule: Conventional `fix:` prefix should map to Fixed.
+  const conventionalFixes = collectMatchingTitles(
+    nonDependencyTitles,
+    (title) => FIX_PREFIX_FLEX_RE.test(title),
+  );
   if (conventionalFixes.length)
     moveTitlesToCategory(adjusted, conventionalFixes, SECTION_FIXED);
 
   // Secondary rule: refactor/perf/style-like items should land in Changed when misclassified as Chore or missing.
-  const isRefactorLike = (raw: string) =>
-    REFACTOR_LIKE_RE.test(raw.toLowerCase());
-  const isChangeLike = (raw: string) => isChangeLikeTitle(raw);
-
-  // Helper to find current category of a title.
-  const findCategory = (title: string): BucketName | undefined => {
-    for (const [section, list] of Object.entries(adjusted)) {
-      if (Array.isArray(list) && list.includes(title) && isBucketName(section))
-        return section;
-    }
-    return undefined;
-  };
-
-  const toChanged: string[] = [];
-  for (const title of nonDependencyTitles) {
-    if (!isRefactorLike(title) && !isChangeLike(title)) continue;
-    const current = findCategory(title);
-    if (current === SECTION_FIXED) continue; // don't override explicit/implicit fixes
-    if (current && current !== SECTION_CHORE && current !== SECTION_ADDED)
-      continue; // already in a specific bucket
-    toChanged.push(title);
-  }
-  if (toChanged.length)
-    moveTitlesToCategory(adjusted, toChanged, SECTION_CHANGED);
+  const changeLikeTitles = nonDependencyTitles.filter((title) =>
+    shouldMoveChangeLikeTitle(title, findCategory(adjusted, title)),
+  );
+  if (changeLikeTitles.length)
+    moveTitlesToCategory(adjusted, changeLikeTitles, SECTION_CHANGED);
 
   // Rule: Conventional `feat:` prefix should map to Added (guard against LLM
   // placing features under Chore/Changed due to generic verbs like "add/support").
-  // Match conventional feat prefixes including optional scope and optional breaking '!'
-  // Examples: feat: msg, feat!: msg, feat(scope): msg, feat(scope)!: msg
-  const FEAT_PREFIX_RE = /^feat(?:!:|(?:\([^)]*\))?!?:)/i;
-  const toAdded: string[] = [];
-  for (const title of nonDependencyTitles) {
-    if (FEAT_PREFIX_RE.test(title)) toAdded.push(title);
-  }
-  if (toAdded.length) moveTitlesToCategory(adjusted, toAdded, SECTION_ADDED);
+  const featureTitles = collectMatchingTitles(nonDependencyTitles, (title) =>
+    FEAT_PREFIX_FLEX_RE.test(title),
+  );
+  if (featureTitles.length)
+    moveTitlesToCategory(adjusted, featureTitles, SECTION_ADDED);
 
-  // Scoring-based remap from weak buckets when confident
-  const WEAK_BUCKETS = new Set<BucketName>([
-    SECTION_CHORE,
-    SECTION_DOCS,
-    SECTION_TEST,
-  ]);
-  for (const title of nonDependencyTitles) {
-    const current = findCategory(title);
-    if (!current || !WEAK_BUCKETS.has(current)) continue;
-    const scores = scoreCategories(title);
-    const guide = bestCategory(scores);
-    if (
-      guide === SECTION_FIXED &&
-      scores[SECTION_FIXED] >= SCORE_THRESHOLDS.fixed
-    ) {
-      moveTitlesToCategory(adjusted, [title], SECTION_FIXED);
-      continue;
-    }
-    if (
-      guide === SECTION_CHANGED &&
-      scores[SECTION_CHANGED] >= SCORE_THRESHOLDS.changed
-    ) {
-      moveTitlesToCategory(adjusted, [title], SECTION_CHANGED);
-      continue;
-    }
-    if (
-      guide === SECTION_ADDED &&
-      scores[SECTION_ADDED] >= SCORE_THRESHOLDS.added
-    ) {
-      moveTitlesToCategory(adjusted, [title], SECTION_ADDED);
-      continue;
-    }
-    if (
-      guide === SECTION_BREAKING_CHANGES &&
-      scores[SECTION_BREAKING_CHANGES] >= SCORE_THRESHOLDS.breaking
-    ) {
-      // Only elevate to Breaking when very confident
-      moveTitlesToCategory(adjusted, [title], SECTION_BREAKING_CHANGES);
-      continue;
-    }
-  }
+  applyScoredWeakBucketRemaps(adjusted, nonDependencyTitles);
 
   return adjusted;
 }


### PR DESCRIPTION
## Summary

Clarify category tuning rules.

<!-- A brief summary of the changes -->

## Description

- Extract category tuning helpers for title collection, map cloning, and bucket lookup
- Move static keyword lists and weak bucket config out of the main tuning flow
- Reuse shared conventional commit prefix regexes for `fix:` and `feat:` remaps

<!-- A detailed explanation of the changes, including why they are needed -->
