### PR TITLE
feat: extract WHY from description sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ The preprocessor recognizes common reason/context section headings in English,
 Spanish, French, German, Portuguese, Italian, Dutch, Japanese, Chinese, Korean,
 and Russian. This is a heading-alias list, not a hard language limit: compact PR
 descriptions in other languages can still reach provider judgment, and missing
-or unclear evidence is still omitted rather than guessed.
+or unclear evidence is still omitted rather than guessed. A `Description`
+section can also supply WHY evidence when its prose explicitly marks the reason,
+for example with `WHY:`, `because`, or `in order to`.
 
 ### Force a specific model (example: gpt-4o-mini)
 

--- a/src/utils/why-preprocess.ts
+++ b/src/utils/why-preprocess.ts
@@ -382,7 +382,7 @@ function scoreCandidateMaterial(
     hasRationaleMarker &&
     sections.some((section) => section.name === 'description')
   ) {
-    score += 1;
+    score += 2;
   }
   if (ISSUE_REF_RE.test(body)) score += 1;
   if (candidateText.length >= 60) score += 1;

--- a/src/utils/why-preprocess.ts
+++ b/src/utils/why-preprocess.ts
@@ -52,7 +52,7 @@ const CONTAINER_CANONICAL_SECTION_NAMES = new Set<WhyCanonicalSectionName>([
 ]);
 
 const RATIONALE_MARKER_RE =
-  /\b(because|so that|in order to|reason|rationale|motivation|to avoid|to prevent|context|problem)\b/i;
+  /\b(why|because|so that|in order to|reason|rationale|motivation|to avoid|to prevent|context|problem)\b|,\s*so\b/i;
 const PROBLEM_MARKER_RE =
   /\b(fix|prevent|avoid|missing|broken|incorrect|regression|failure|bug|issue|risk|support|compatib|performance)\b/i;
 const ISSUE_REF_RE =
@@ -375,6 +375,15 @@ function scoreCandidateMaterial(
   const hasProblemMarker = PROBLEM_MARKER_RE.test(candidateText);
   if (hasRationaleMarker) score += 3;
   if (hasProblemMarker) score += 2;
+  // WHY: Description sections often combine WHAT and WHY. Promote them only
+  // when the prose explicitly signals rationale, rather than trusting any
+  // generic description as sufficient evidence.
+  if (
+    hasRationaleMarker &&
+    sections.some((section) => section.name === 'description')
+  ) {
+    score += 1;
+  }
   if (ISSUE_REF_RE.test(body)) score += 1;
   if (candidateText.length >= 60) score += 1;
   if (candidateText.length > 500) score += 1;

--- a/src/utils/why-preprocess.ts
+++ b/src/utils/why-preprocess.ts
@@ -371,16 +371,23 @@ function scoreCandidateMaterial(
   ) {
     score += 2;
   }
-  const hasRationaleMarker = RATIONALE_MARKER_RE.test(candidateText);
+  const hasInlineWhyLabel = sections.some(
+    (section) => section.name === 'why' && section.source === 'inline-label',
+  );
+  // WHY: Inline labels are removed from candidate text, so retain their
+  // explicit rationale signal for trust scoring.
+  const hasRationaleMarker =
+    RATIONALE_MARKER_RE.test(candidateText) || hasInlineWhyLabel;
   const hasProblemMarker = PROBLEM_MARKER_RE.test(candidateText);
   if (hasRationaleMarker) score += 3;
   if (hasProblemMarker) score += 2;
-  // WHY: Description sections often combine WHAT and WHY. Promote them only
-  // when the prose explicitly signals rationale, rather than trusting any
-  // generic description as sufficient evidence.
+  // WHY: Description prose must explicitly signal rationale. An inline Why
+  // label is equally explicit even though container extraction removes its
+  // Description parent.
   if (
     hasRationaleMarker &&
-    sections.some((section) => section.name === 'description')
+    (hasInlineWhyLabel ||
+      sections.some((section) => section.name === 'description'))
   ) {
     score += 2;
   }

--- a/tests/utils/why-preprocess.test.ts
+++ b/tests/utils/why-preprocess.test.ts
@@ -180,6 +180,68 @@ describe('why-preprocess', () => {
     expect(candidates).not.toContain('Listen to release published events');
   });
 
+  test('builds a trusted candidate from explicit WHY prose in Description', () => {
+    const result = preprocessWhyPrBody(
+      target,
+      details({
+        body: [
+          '## Description',
+          '',
+          'This restores the release workflow event handling.',
+          '',
+          'WHY: Draft releases can be published later, so changelog generation must run at publication time.',
+          '',
+          '## Testing',
+          'Verified manually.',
+        ].join('\n'),
+      }),
+      { maxCharsPerPr: 800 },
+    );
+
+    const candidates = result.item?.candidates.join('\n') ?? '';
+
+    expect(result.item?.trustScore).toBeGreaterThanOrEqual(7);
+    expect(candidates).toContain('Draft releases can be published later');
+    expect(candidates).not.toContain('This restores the release workflow');
+    expect(candidates).not.toContain('Verified manually');
+  });
+
+  test('builds a trusted candidate from rationale prose in Description', () => {
+    const result = preprocessWhyPrBody(
+      target,
+      details({
+        body: [
+          '## Description',
+          '',
+          'This restores the workflow because draft releases can be published later and need changelog generation at publication time.',
+        ].join('\n'),
+      }),
+      { maxCharsPerPr: 800 },
+    );
+
+    expect(result.item?.trustScore).toBeGreaterThanOrEqual(7);
+    expect(result.item?.candidates.join('\n')).toContain(
+      'because draft releases can be published later',
+    );
+  });
+
+  test('does not trust generic Description prose without rationale evidence', () => {
+    const result = preprocessWhyPrBody(
+      target,
+      details({
+        body: [
+          '## Description',
+          '',
+          'This updates the release workflow event handling and related configuration.',
+        ].join('\n'),
+      }),
+      { maxCharsPerPr: 800 },
+    );
+
+    expect(result.item).toBeUndefined();
+    expect(result.lowTrust).toBe(true);
+  });
+
   test('keeps inline why labels after container label blocks', () => {
     const result = preprocessWhyPrBody(
       target,

--- a/tests/utils/why-preprocess.test.ts
+++ b/tests/utils/why-preprocess.test.ts
@@ -189,7 +189,7 @@ describe('why-preprocess', () => {
           '',
           'This restores the release workflow event handling.',
           '',
-          'WHY: Draft releases can be published later, so changelog generation must run at publication time.',
+          'WHY: Users need release notes when drafts are published.',
           '',
           '## Testing',
           'Verified manually.',
@@ -200,8 +200,10 @@ describe('why-preprocess', () => {
 
     const candidates = result.item?.candidates.join('\n') ?? '';
 
-    expect(result.item?.trustScore).toBeGreaterThanOrEqual(7);
-    expect(candidates).toContain('Draft releases can be published later');
+    expect(result.item?.trustScore).toBe(9);
+    expect(candidates).toContain(
+      'Users need release notes when drafts are published.',
+    );
     expect(candidates).not.toContain('This restores the release workflow');
     expect(candidates).not.toContain('Verified manually');
   });

--- a/tests/utils/why-preprocess.test.ts
+++ b/tests/utils/why-preprocess.test.ts
@@ -213,15 +213,15 @@ describe('why-preprocess', () => {
         body: [
           '## Description',
           '',
-          'This restores the workflow because draft releases can be published later and need changelog generation at publication time.',
+          'Adds retries because GitHub returns 502.',
         ].join('\n'),
       }),
       { maxCharsPerPr: 800 },
     );
 
-    expect(result.item?.trustScore).toBeGreaterThanOrEqual(7);
-    expect(result.item?.candidates.join('\n')).toContain(
-      'because draft releases can be published later',
+    expect(result.item?.trustScore).toBe(7);
+    expect(result.item?.candidates).toContain(
+      'Adds retries because GitHub returns 502.',
     );
   });
 


### PR DESCRIPTION
## Summary

Extract WHY from description sections.

<!-- A brief summary of the changes -->

## Description

- Extract explicit rationale from `Description` sections using markers such as `WHY:`, `because`, and `in order to`
- Keep generic description prose below the trust threshold to prevent false positives
- Document the behavior and add regression coverage

<!-- A detailed explanation of the changes, including why they are needed -->
