### PR TITLE
refactor: centralize provider classification fallback

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -16,8 +16,7 @@ import { PROVIDER_ANTHROPIC } from '@/constants/provider.js';
 import { RELEASE_NOTES_SYSTEM_PROMPT } from '@/constants/system-prompts.js';
 import {
   buildClassificationPrompt,
-  fallbackCategoryMap,
-  parseCategoryMap,
+  classifyTitlesWithFallback,
 } from '@/providers/classification.js';
 import { isRecord, isString } from '@/utils/is.js';
 import type { CategoryMap } from '@/types/changelog.js';
@@ -115,56 +114,51 @@ export class AnthropicProvider implements Provider {
     titles: string[],
     options: ClassifyTitlesOptions = {},
   ): Promise<CategoryMap> {
-    if (!titles.length) return {};
-    if (!this.apiKey) return fallbackCategoryMap(titles);
+    return classifyTitlesWithFallback({
+      titles,
+      hasApiKey: Boolean(this.apiKey),
+      options,
+      invalidResponseMessage: 'Anthropic classify output did not match schema',
+      request: async () => {
+        const prompt = buildClassificationPrompt(titles);
+        const properties: Record<string, unknown> = {};
+        for (const category of prompt.categories) {
+          properties[category] = { type: 'array', items: { type: 'string' } };
+        }
 
-    const prompt = buildClassificationPrompt(titles);
-    const properties: Record<string, unknown> = {};
-    for (const category of prompt.categories) {
-      properties[category] = { type: 'array', items: { type: 'string' } };
-    }
+        const payload = {
+          model: this.modelName,
+          max_tokens: LLM_CLASSIFY_MAX_TOKENS,
+          temperature: 0,
+          system: SYSTEM_ANTHROPIC_CLASSIFY,
+          messages: [{ role: 'user', content: JSON.stringify(prompt) }],
+          tools: [
+            {
+              name: 'return_categories',
+              description:
+                'Return a JSON object mapping each category to an array of titles.',
+              input_schema: {
+                type: 'object',
+                properties,
+                additionalProperties: false,
+              },
+            },
+          ],
+          tool_choice: { type: 'tool', name: 'return_categories' },
+        } as const;
 
-    const payload = {
-      model: this.modelName,
-      max_tokens: LLM_CLASSIFY_MAX_TOKENS,
-      temperature: 0,
-      system: SYSTEM_ANTHROPIC_CLASSIFY,
-      messages: [{ role: 'user', content: JSON.stringify(prompt) }],
-      tools: [
-        {
-          name: 'return_categories',
-          description:
-            'Return a JSON object mapping each category to an array of titles.',
-          input_schema: {
-            type: 'object',
-            properties,
-            additionalProperties: false,
+        const json = await postJson<unknown>(
+          ANTHROPIC_API,
+          payload,
+          {
+            'x-api-key': this.apiKey ?? '',
+            'anthropic-version': ANTHROPIC_VERSION,
           },
-        },
-      ],
-      tool_choice: { type: 'tool', name: 'return_categories' },
-    } as const;
-
-    try {
-      const json = await postJson<unknown>(
-        ANTHROPIC_API,
-        payload,
-        {
-          'x-api-key': this.apiKey,
-          'anthropic-version': ANTHROPIC_VERSION,
-        },
-        'Anthropic classify error',
-      );
-      const text = extractAnthropicClassificationResponse(json) || '{}';
-      const categories = parseCategoryMap(text);
-      if (!categories) {
-        throw new Error('Anthropic classify output did not match schema');
-      }
-      return categories;
-    } catch (err) {
-      if (options.throwOnError) throw err;
-      return fallbackCategoryMap(titles);
-    }
+          'Anthropic classify error',
+        );
+        return extractAnthropicClassificationResponse(json) || '{}';
+      },
+    });
   }
 
   async extractWhyNotes(

--- a/src/providers/classification.ts
+++ b/src/providers/classification.ts
@@ -1,5 +1,6 @@
 import { SECTION_CHORE, SECTION_ORDER } from '@/constants/changelog.js';
 import type { CategoryMap } from '@/types/changelog.js';
+import type { ClassifyTitlesOptions } from '@/types/provider.js';
 import { isRecord, isString } from '@/utils/is.js';
 
 /** Prompt payload sent to classification LLMs. */
@@ -56,5 +57,40 @@ export function parseCategoryMap(rawJson: string): CategoryMap | undefined {
     return result;
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * Run provider classification with the shared fallback and error policy.
+ * @param params Classification inputs and provider-specific request callback.
+ * @returns Parsed categories, an empty map for empty input, or the deterministic fallback.
+ */
+export async function classifyTitlesWithFallback(params: {
+  titles: string[];
+  hasApiKey: boolean;
+  options?: ClassifyTitlesOptions;
+  request: () => Promise<string>;
+  invalidResponseMessage: string;
+}): Promise<CategoryMap> {
+  const {
+    titles,
+    hasApiKey,
+    options = {},
+    request,
+    invalidResponseMessage,
+  } = params;
+
+  if (!titles.length) return {};
+  if (!hasApiKey) return fallbackCategoryMap(titles);
+
+  try {
+    const categories = parseCategoryMap(await request());
+    if (!categories) {
+      throw new Error(invalidResponseMessage);
+    }
+    return categories;
+  } catch (error) {
+    if (options.throwOnError) throw error;
+    return fallbackCategoryMap(titles);
   }
 }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -17,8 +17,7 @@ import { PROVIDER_GEMINI } from '@/constants/provider.js';
 import { RELEASE_NOTES_SYSTEM_PROMPT } from '@/constants/system-prompts.js';
 import {
   buildClassificationPrompt,
-  fallbackCategoryMap,
-  parseCategoryMap,
+  classifyTitlesWithFallback,
 } from '@/providers/classification.js';
 import {
   buildWhyExtractionPrompt,
@@ -127,54 +126,50 @@ export class GeminiProvider implements Provider {
     titles: string[],
     options: ClassifyTitlesOptions = {},
   ): Promise<CategoryMap> {
-    if (!titles.length) return {};
-    if (!this.apiKey) return fallbackCategoryMap(titles);
+    return classifyTitlesWithFallback({
+      titles,
+      hasApiKey: Boolean(this.apiKey),
+      options,
+      invalidResponseMessage: 'Gemini classify output did not match schema',
+      request: async () => {
+        const prompt = buildClassificationPrompt(titles);
+        const properties: Record<string, unknown> = {};
+        for (const category of prompt.categories) {
+          properties[category] = { type: 'array', items: { type: 'string' } };
+        }
 
-    const prompt = buildClassificationPrompt(titles);
-    const properties: Record<string, unknown> = {};
-    for (const category of prompt.categories) {
-      properties[category] = { type: 'array', items: { type: 'string' } };
-    }
+        const payload = {
+          systemInstruction: {
+            parts: [{ text: SYSTEM_GEMINI_CLASSIFY }],
+          },
+          contents: [
+            {
+              role: 'user',
+              parts: [{ text: JSON.stringify(prompt) }],
+            },
+          ],
+          generationConfig: {
+            maxOutputTokens: LLM_CLASSIFY_MAX_TOKENS,
+            temperature: 0,
+            responseMimeType: 'application/json',
+            responseJsonSchema: {
+              type: 'object',
+              properties,
+              required: [...prompt.categories],
+              additionalProperties: false,
+            },
+          },
+        } as const;
 
-    const payload = {
-      systemInstruction: {
-        parts: [{ text: SYSTEM_GEMINI_CLASSIFY }],
+        const response = await postJson<GeminiResponse>(
+          buildGeminiGenerateUrl(this.modelName),
+          payload,
+          { 'x-goog-api-key': this.apiKey ?? '' },
+          'Gemini classify error',
+        );
+        return extractGeminiText(response);
       },
-      contents: [
-        {
-          role: 'user',
-          parts: [{ text: JSON.stringify(prompt) }],
-        },
-      ],
-      generationConfig: {
-        maxOutputTokens: LLM_CLASSIFY_MAX_TOKENS,
-        temperature: 0,
-        responseMimeType: 'application/json',
-        responseJsonSchema: {
-          type: 'object',
-          properties,
-          required: [...prompt.categories],
-          additionalProperties: false,
-        },
-      },
-    } as const;
-
-    try {
-      const response = await postJson<GeminiResponse>(
-        buildGeminiGenerateUrl(this.modelName),
-        payload,
-        { 'x-goog-api-key': this.apiKey },
-        'Gemini classify error',
-      );
-      const categories = parseCategoryMap(extractGeminiText(response));
-      if (!categories) {
-        throw new Error('Gemini classify output did not match schema');
-      }
-      return categories;
-    } catch (err) {
-      if (options.throwOnError) throw err;
-      return fallbackCategoryMap(titles);
-    }
+    });
   }
 
   async extractWhyNotes(

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -18,8 +18,7 @@ import { PROVIDER_OPENAI } from '@/constants/provider.js';
 import { RELEASE_NOTES_SYSTEM_PROMPT } from '@/constants/system-prompts.js';
 import {
   buildClassificationPrompt,
-  fallbackCategoryMap,
-  parseCategoryMap,
+  classifyTitlesWithFallback,
 } from '@/providers/classification.js';
 import type { CategoryMap } from '@/types/changelog.js';
 import {
@@ -144,56 +143,51 @@ export class OpenAIProvider implements Provider {
     titles: string[],
     options: ClassifyTitlesOptions = {},
   ): Promise<CategoryMap> {
-    if (!titles.length) return {};
-    if (!this.apiKey) return fallbackCategoryMap(titles);
-
-    const prompt = buildClassificationPrompt(titles);
-
-    try {
-      let text: string;
-      if (isReasoningModel(this.modelName)) {
-        const payload = buildOpenAiResponsePayload(
-          this.modelName,
-          SYSTEM_OPENAI_CLASSIFY,
-          JSON.stringify(prompt),
-          LLM_CLASSIFY_MAX_TOKENS,
-        );
-        const response = await postJson<OpenAIResponse>(
-          OPENAI_RESPONSES_API,
-          payload,
-          { Authorization: `Bearer ${this.apiKey}` },
-          'OpenAI classify error',
-        );
-        text = extractOpenAiResponseText(response);
-      } else {
-        const payload = {
-          model: this.modelName,
-          max_tokens: LLM_CLASSIFY_MAX_TOKENS,
-          temperature: 0,
-          messages: [
-            { role: 'system', content: SYSTEM_OPENAI_CLASSIFY },
-            { role: 'user', content: JSON.stringify(prompt) },
-          ],
-          // Enforce strict JSON object output for robust parsing.
-          response_format: { type: 'json_object' },
-        } as const;
-        const response = await postJson<unknown>(
-          OPENAI_CHAT_API,
-          payload,
-          { Authorization: `Bearer ${this.apiKey}` },
-          'OpenAI classify error',
-        );
-        text = extractOpenAiClassificationResponse(response);
-      }
-      const categories = parseCategoryMap(text);
-      if (!categories) {
-        throw new Error('OpenAI classify output did not match schema');
-      }
-      return categories;
-    } catch (err) {
-      if (options.throwOnError) throw err;
-      return fallbackCategoryMap(titles);
-    }
+    return classifyTitlesWithFallback({
+      titles,
+      hasApiKey: Boolean(this.apiKey),
+      options,
+      invalidResponseMessage: 'OpenAI classify output did not match schema',
+      request: async () => {
+        const prompt = buildClassificationPrompt(titles);
+        let text: string;
+        if (isReasoningModel(this.modelName)) {
+          const payload = buildOpenAiResponsePayload(
+            this.modelName,
+            SYSTEM_OPENAI_CLASSIFY,
+            JSON.stringify(prompt),
+            LLM_CLASSIFY_MAX_TOKENS,
+          );
+          const response = await postJson<OpenAIResponse>(
+            OPENAI_RESPONSES_API,
+            payload,
+            { Authorization: `Bearer ${this.apiKey}` },
+            'OpenAI classify error',
+          );
+          text = extractOpenAiResponseText(response);
+        } else {
+          const payload = {
+            model: this.modelName,
+            max_tokens: LLM_CLASSIFY_MAX_TOKENS,
+            temperature: 0,
+            messages: [
+              { role: 'system', content: SYSTEM_OPENAI_CLASSIFY },
+              { role: 'user', content: JSON.stringify(prompt) },
+            ],
+            // Enforce strict JSON object output for robust parsing.
+            response_format: { type: 'json_object' },
+          } as const;
+          const response = await postJson<unknown>(
+            OPENAI_CHAT_API,
+            payload,
+            { Authorization: `Bearer ${this.apiKey}` },
+            'OpenAI classify error',
+          );
+          text = extractOpenAiClassificationResponse(response);
+        }
+        return text;
+      },
+    });
   }
 
   async extractWhyNotes(

--- a/tests/providers/anthropic.test.ts
+++ b/tests/providers/anthropic.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+
+import { AnthropicProvider } from '@/providers/anthropic.js';
+
+describe('AnthropicProvider', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('classifies titles from structured tool output', async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [
+            {
+              type: 'tool_use',
+              name: 'return_categories',
+              input: { Added: ['Add Anthropic support'] },
+            },
+          ],
+        }),
+      ),
+    );
+    global.fetch = fetchMock;
+    const provider = new AnthropicProvider({
+      apiKey: 'anthropic-test',
+      model: 'claude-test-model',
+    });
+
+    const output = await provider.classifyTitles(['Add Anthropic support'], {
+      throwOnError: true,
+    });
+
+    expect(output).toEqual({ Added: ['Add Anthropic support'] });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/messages',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'anthropic-version': '2023-06-01',
+          'x-api-key': 'anthropic-test',
+        }),
+      }),
+    );
+    const requestBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(requestBody).toEqual(
+      expect.objectContaining({
+        model: 'claude-test-model',
+        max_tokens: 1000,
+        tool_choice: { type: 'tool', name: 'return_categories' },
+      }),
+    );
+  });
+});

--- a/tests/providers/classification.test.ts
+++ b/tests/providers/classification.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+import { classifyTitlesWithFallback } from '@/providers/classification.js';
+
+describe('classifyTitlesWithFallback', () => {
+  test('returns an empty map without requesting classification for empty input', async () => {
+    const request = jest.fn<() => Promise<string>>();
+
+    const result = await classifyTitlesWithFallback({
+      titles: [],
+      hasApiKey: true,
+      request,
+      invalidResponseMessage: 'Invalid response',
+    });
+
+    expect(result).toEqual({});
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test('uses the deterministic fallback without a provider key', async () => {
+    const request = jest.fn<() => Promise<string>>();
+
+    const result = await classifyTitlesWithFallback({
+      titles: ['Update dependencies'],
+      hasApiKey: false,
+      request,
+      invalidResponseMessage: 'Invalid response',
+    });
+
+    expect(result).toEqual({ Chore: ['Update dependencies'] });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test('parses a valid provider response', async () => {
+    const result = await classifyTitlesWithFallback({
+      titles: ['Fix release lookup'],
+      hasApiKey: true,
+      request: async () => JSON.stringify({ Fixed: ['Fix release lookup'] }),
+      invalidResponseMessage: 'Invalid response',
+    });
+
+    expect(result).toEqual({ Fixed: ['Fix release lookup'] });
+  });
+
+  test('falls back when the provider request fails', async () => {
+    const result = await classifyTitlesWithFallback({
+      titles: ['Update dependencies'],
+      hasApiKey: true,
+      request: async () => {
+        throw new Error('Provider unavailable');
+      },
+      invalidResponseMessage: 'Invalid response',
+    });
+
+    expect(result).toEqual({ Chore: ['Update dependencies'] });
+  });
+
+  test('propagates invalid provider responses when requested', async () => {
+    await expect(
+      classifyTitlesWithFallback({
+        titles: ['Fix release lookup'],
+        hasApiKey: true,
+        options: { throwOnError: true },
+        request: async () => '{}',
+        invalidResponseMessage: 'Invalid provider response',
+      }),
+    ).rejects.toThrow('Invalid provider response');
+  });
+});


### PR DESCRIPTION
## Summary

Centralize provider classification fallback.

<!-- A brief summary of the changes -->

## Description

  Centralizes title-classification parsing, fallback behavior, and error handling across OpenAI, Anthropic, and Gemini providers.
 
- Extracts shared classification flow into `classifyTitlesWithFallback`
- Preserves provider-specific request payloads

<!-- A detailed explanation of the changes, including why they are needed -->
