### PR TITLE
fix: normalize semver-style release names

### DIFF
--- a/src/lib/release-context.ts
+++ b/src/lib/release-context.ts
@@ -10,7 +10,7 @@ import { getProviderRuntimeConfig } from '@/lib/app-config.js';
 import type { AppConfig } from '@/types/config.js';
 import type { ProviderName } from '@/types/llm.js';
 import { resolveGitHubAuth } from '@/utils/github-auth.js';
-import { versionFromRef } from '@/utils/version.js';
+import { normalizeReleaseName, versionFromRef } from '@/utils/version.js';
 import { escapeRegExp } from '@/utils/escape.js';
 import { HEAD_REF } from '@/constants/git.js';
 import { DATE_YYYY_MM_DD_LEN } from '@/constants/time.js';
@@ -56,7 +56,9 @@ export function resolveReleasePlan(
   const [owner, repo] = repoFullName.split('/');
   const releaseRef =
     cli.releaseTag || tryDetectLatestTag(cli.repoPath) || HEAD_REF;
-  const version = versionFromRef(cli.releaseName || releaseRef);
+  const version = cli.releaseName
+    ? normalizeReleaseName(cli.releaseName)
+    : versionFromRef(releaseRef);
   const prevRef =
     tryDetectPrevTag(releaseRef, cli.repoPath) || firstCommit(cli.repoPath);
   const date =

--- a/src/lib/release-context.ts
+++ b/src/lib/release-context.ts
@@ -56,7 +56,7 @@ export function resolveReleasePlan(
   const [owner, repo] = repoFullName.split('/');
   const releaseRef =
     cli.releaseTag || tryDetectLatestTag(cli.repoPath) || HEAD_REF;
-  const version = cli.releaseName || versionFromRef(releaseRef);
+  const version = versionFromRef(cli.releaseName || releaseRef);
   const prevRef =
     tryDetectPrevTag(releaseRef, cli.repoPath) || firstCommit(cli.repoPath);
   const date =

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,12 +1,13 @@
 import { HEAD_REF } from '@/constants/git.js';
 
 /**
- * Convert a git ref to a version string, stripping leading `v`.
+ * Convert a git ref to a version string, stripping a semver-style leading `v`.
  * `HEAD` is mapped to a dev placeholder version.
- * WHY: We allow users to run dry-runs against `HEAD` without tagging.
+ * WHY: Strip `v` only before a digit so ordinary labels such as
+ * `version-2026` are preserved.
  * @param ref Git ref, e.g., `v1.2.3` or `HEAD`.
  * @returns Bare version string, e.g., `1.2.3` or `0.0.0-dev`.
  */
 export function versionFromRef(ref: string): string {
-  return ref === HEAD_REF ? '0.0.0-dev' : String(ref).replace(/^v/, '');
+  return ref === HEAD_REF ? '0.0.0-dev' : String(ref).replace(/^v(?=\d)/, '');
 }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,6 +1,17 @@
 import { HEAD_REF } from '@/constants/git.js';
 
 /**
+ * Normalize a release name by stripping a semver-style leading `v`.
+ * WHY: Explicit display names must otherwise remain unchanged, including
+ * reserved ref names such as `HEAD`.
+ * @param releaseName Caller-provided release display name.
+ * @returns Normalized release name.
+ */
+export function normalizeReleaseName(releaseName: string): string {
+  return releaseName.replace(/^v(?=\d)/, '');
+}
+
+/**
  * Convert a git ref to a version string, stripping a semver-style leading `v`.
  * `HEAD` is mapped to a dev placeholder version.
  * WHY: Strip `v` only before a digit so ordinary labels such as
@@ -9,5 +20,5 @@ import { HEAD_REF } from '@/constants/git.js';
  * @returns Bare version string, e.g., `1.2.3` or `0.0.0-dev`.
  */
 export function versionFromRef(ref: string): string {
-  return ref === HEAD_REF ? '0.0.0-dev' : String(ref).replace(/^v(?=\d)/, '');
+  return ref === HEAD_REF ? '0.0.0-dev' : normalizeReleaseName(ref);
 }

--- a/tests/lib/release-context.test.ts
+++ b/tests/lib/release-context.test.ts
@@ -81,6 +81,28 @@ describe('lib/release-context', () => {
     expect(plan.version).toBe('1.2.0');
   });
 
+  test('preserves HEAD when explicitly supplied as the release name', () => {
+    tryDetectPrevTag.mockReturnValue('v1.1.0');
+    dateForRef.mockReturnValue('2026-04-10');
+
+    const plan = resolveReleasePlan(
+      {
+        repoPath: '/repo',
+        changelogPath: 'CHANGELOG.md',
+        baseBranch: 'main',
+        provider: 'openai',
+        releaseTag: 'v1.2.0',
+        releaseName: 'HEAD',
+        releaseBody: '',
+        dryRun: false,
+      },
+      'octo/repo',
+    );
+
+    expect(plan.releaseRef).toBe('v1.2.0');
+    expect(plan.version).toBe('HEAD');
+  });
+
   test('removes an existing compare link for the current version', () => {
     readChangelog.mockReturnValue(
       [

--- a/tests/lib/release-context.test.ts
+++ b/tests/lib/release-context.test.ts
@@ -59,6 +59,28 @@ describe('lib/release-context', () => {
     });
   });
 
+  test('normalizes a semver-style release name without changing its release ref', () => {
+    tryDetectPrevTag.mockReturnValue('v1.1.0');
+    dateForRef.mockReturnValue('2026-04-10');
+
+    const plan = resolveReleasePlan(
+      {
+        repoPath: '/repo',
+        changelogPath: 'CHANGELOG.md',
+        baseBranch: 'main',
+        provider: 'openai',
+        releaseTag: 'v1.2.0',
+        releaseName: 'v1.2.0',
+        releaseBody: '',
+        dryRun: false,
+      },
+      'octo/repo',
+    );
+
+    expect(plan.releaseRef).toBe('v1.2.0');
+    expect(plan.version).toBe('1.2.0');
+  });
+
   test('removes an existing compare link for the current version', () => {
     readChangelog.mockReturnValue(
       [

--- a/tests/utils/version.test.ts
+++ b/tests/utils/version.test.ts
@@ -1,6 +1,16 @@
 // @ts-nocheck
 import { describe, test, expect } from '@jest/globals';
-import { versionFromRef } from '@/utils/version.js';
+import { normalizeReleaseName, versionFromRef } from '@/utils/version.js';
+
+describe('normalizeReleaseName', () => {
+  test('strips a leading v before a numeric version', () => {
+    expect(normalizeReleaseName('v1.2.3')).toBe('1.2.3');
+  });
+  test('preserves explicit HEAD and ordinary labels', () => {
+    expect(normalizeReleaseName('HEAD')).toBe('HEAD');
+    expect(normalizeReleaseName('version-2026')).toBe('version-2026');
+  });
+});
 
 describe('versionFromRef', () => {
   test('strips a leading v before a numeric version', () => {

--- a/tests/utils/version.test.ts
+++ b/tests/utils/version.test.ts
@@ -3,8 +3,11 @@ import { describe, test, expect } from '@jest/globals';
 import { versionFromRef } from '@/utils/version.js';
 
 describe('versionFromRef', () => {
-  test('strips leading v', () => {
+  test('strips a leading v before a numeric version', () => {
     expect(versionFromRef('v1.2.3')).toBe('1.2.3');
+  });
+  test('preserves a leading v in an ordinary label', () => {
+    expect(versionFromRef('version-2026')).toBe('version-2026');
   });
   test('HEAD maps to dev version', () => {
     expect(versionFromRef('HEAD')).toBe('0.0.0-dev');


### PR DESCRIPTION
## Summary

Normalize semver-style release names.

<!-- A brief summary of the changes -->

## Description

- Normalize explicit release names such as `v1.1.0` to `1.1.0`.
- Strip a leading `v` only when followed by a digit.
- Preserve ordinary labels such as `version-2026`.

<!-- A detailed explanation of the changes, including why they are needed -->
