### PR TITLE
refactor: standardize runtime type guards with is-kit

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,10 +2,11 @@
 
 import { runCli } from './index.js';
 import { mapErrorToExitCode } from '@/lib/errors.js';
+import { isError } from '@/utils/is.js';
 
 // WHY: Splitting the executable wrapper keeps the shebang intact without polluting the reusable CLI module.
 runCli().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
+  console.error(isError(error) ? error.message : error);
   const code = mapErrorToExitCode(error);
   process.exit(code);
 });

--- a/src/lib/changelog-sections.ts
+++ b/src/lib/changelog-sections.ts
@@ -1,6 +1,7 @@
 import { UNRELEASED_ANCHOR } from '@/constants/changelog.js';
 import { ANY_H2_HEADING_RE } from '@/constants/markdown.js';
 import { escapeRegExp } from '@/utils/escape.js';
+import { isUndefined } from '@/utils/is.js';
 
 /**
  * Insert a rendered section below the given anchor heading, or near the top when absent.
@@ -31,7 +32,7 @@ export function insertSection(
     'm',
   );
   const anchorMatch = changelog.match(anchorRegExp);
-  if (anchorMatch && anchorMatch.index !== undefined) {
+  if (anchorMatch && !isUndefined(anchorMatch.index)) {
     const anchorStartIndex = anchorMatch.index;
     const anchorLine = anchorMatch[0];
     const beforeAnchor = changelog.slice(0, anchorStartIndex);
@@ -46,7 +47,7 @@ export function insertSection(
 
   // Find the first "## " heading which marks the start of changelog sections
   const firstHeadingMatch = existingContent.match(ANY_H2_HEADING_RE);
-  if (firstHeadingMatch?.index !== undefined) {
+  if (!isUndefined(firstHeadingMatch?.index)) {
     const firstHeadingIndex = firstHeadingMatch.index;
     if (firstHeadingIndex > 0) {
       // There is a header block before the first section

--- a/src/lib/cli-args.ts
+++ b/src/lib/cli-args.ts
@@ -7,6 +7,9 @@ import { PROVIDER_NAMES, PROVIDER_OPENAI } from '@/constants/provider.js';
 import type { ProviderName } from '@/types/llm.js';
 import { loadCliConfigFile } from '@/lib/config-file.js';
 import { ConfigError } from '@/lib/errors.js';
+import { isInstanceOf, isUndefined } from '@/utils/is.js';
+
+const isZodError = isInstanceOf(z.ZodError);
 
 type ParseCliArgsOptions = {
   /** Directory used to resolve config files. */
@@ -17,7 +20,7 @@ function omitUndefined<T extends Record<string, unknown>>(
   value: T,
 ): Partial<T> {
   return Object.fromEntries(
-    Object.entries(value).filter(([, fieldValue]) => fieldValue !== undefined),
+    Object.entries(value).filter(([, fieldValue]) => !isUndefined(fieldValue)),
   ) as Partial<T>;
 }
 
@@ -84,7 +87,7 @@ export async function parseCliArgs(
     dryRunJsonReport: parsed['dry-run-json-report'],
     failOnLlmError: parsed['fail-on-llm-error'],
     requireProvider: parsed['require-provider'],
-    noAi: parsed.ai === undefined ? undefined : !parsed.ai,
+    noAi: isUndefined(parsed.ai) ? undefined : !parsed.ai,
     why: parsed.why,
     whyMaxPrs: parsed['why-max-prs'],
     whyMaxCharsPerPr: parsed['why-max-chars-per-pr'],
@@ -99,7 +102,7 @@ export async function parseCliArgs(
       ...cliOverrides,
     });
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (isZodError(error)) {
       throw new ConfigError(`Invalid CLI options: ${z.prettifyError(error)}`);
     }
     throw error;

--- a/src/lib/config-file.ts
+++ b/src/lib/config-file.ts
@@ -7,8 +7,10 @@ import {
   type CliConfigFile,
 } from '@/schema/config-file.js';
 import { ConfigError } from '@/lib/errors.js';
+import { isError, isInstanceOf } from '@/utils/is.js';
 
 const CLI_CONFIG_ENCODING = 'utf8';
+const isZodError = isInstanceOf(z.ZodError);
 
 /**
  * Load optional CLI configuration from JSON.
@@ -36,12 +38,12 @@ export function loadCliConfigFile(
     );
     return CliConfigFileSchema.parse(rawConfig);
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (isZodError(error)) {
       throw new ConfigError(
         `Invalid config file ${resolvedPath}: ${z.prettifyError(error)}`,
       );
     }
-    const message = error instanceof Error ? error.message : String(error);
+    const message = isError(error) ? error.message : String(error);
     throw new ConfigError(`Invalid config file ${resolvedPath}: ${message}`);
   }
 }

--- a/src/lib/customization.ts
+++ b/src/lib/customization.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
+import { isError } from '@/utils/is.js';
 
 export const CUSTOM_INSTRUCTIONS_ENCODING = 'utf8';
 export const CUSTOM_INSTRUCTIONS_MAX_CHARS = 16_000;
@@ -93,7 +94,7 @@ export function resolveCustomInstructionsWithDiagnostics(
       fileStatus = fileInstructions ? 'loaded' : 'empty';
     } catch (error) {
       fileStatus = 'read_failed';
-      fileError = error instanceof Error ? error.message : String(error);
+      fileError = isError(error) ? error.message : String(error);
     }
   }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -9,6 +9,7 @@ import {
   EXIT_USAGE,
   EXIT_VALIDATION,
 } from '@/constants/errors.js';
+import { isInstanceOf } from '@/utils/is.js';
 
 /** Base application error with optional exit code hint. */
 export class AppError extends Error {
@@ -20,6 +21,8 @@ export class AppError extends Error {
     this.exitCode = exitCode;
   }
 }
+
+const isAppError = isInstanceOf(AppError);
 
 /** Misconfiguration or invalid CLI/env/config values. */
 export class ConfigError extends AppError {
@@ -55,7 +58,7 @@ export class ValidationError extends AppError {
  * @returns Exit code to use with `process.exit`.
  */
 export function mapErrorToExitCode(error: unknown): number {
-  if (error instanceof AppError) return error.exitCode ?? 1;
+  if (isAppError(error)) return error.exitCode ?? 1;
   // Default nonzero exit code for untyped errors.
   return 1;
 }

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { HEAD_REF } from '@/constants/git.js';
 import { GitError } from '@/lib/errors.js';
+import { isError, isNull } from '@/utils/is.js';
 
 /**
  * Pattern that whitelists simple tag or branch names (alphanumeric plus ._-).
@@ -46,7 +47,7 @@ export function run(args: readonly string[], cwd?: string): string {
   try {
     return execFileSync('git', args, { encoding: 'utf8', cwd }).trim();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = isError(error) ? error.message : String(error);
     throw new GitError(`Git command failed: git ${args.join(' ')}. ${message}`);
   }
 }
@@ -200,7 +201,7 @@ export function extractPrRefsFromText(text: string): number[] {
   const numbers = new Set<number>();
   const regExp = /#(\d+)/g;
   let match: RegExpExecArray | null;
-  while ((match = regExp.exec(text)) !== null) {
+  while (!isNull((match = regExp.exec(text)))) {
     numbers.add(Number(match[1]));
   }
   return [...numbers];

--- a/src/lib/pr.ts
+++ b/src/lib/pr.ts
@@ -6,6 +6,7 @@ import {
   GIT_REMOTE,
 } from '@/constants/git.js';
 import type { CreatePRParams } from '@/types/pr.js';
+import { isError } from '@/utils/is.js';
 
 type GitArgs = readonly [string, ...string[]];
 const INVALID_BRANCH_PUNCTUATION = ' ~^:?*[';
@@ -131,7 +132,7 @@ export async function createPR(params: CreatePRParams) {
         labels,
       });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = isError(err) ? err.message : String(err);
       console.warn(`Warning: Failed to apply PR labels: ${message}`);
     }
   }

--- a/src/lib/why-extraction.ts
+++ b/src/lib/why-extraction.ts
@@ -18,6 +18,7 @@ import {
   appendWhyPreview,
   githubWebHost,
 } from '@/lib/why-extraction-notes.js';
+import { isError } from '@/utils/is.js';
 
 type RunWhyExtractionParams = {
   /** Parsed CLI options controlling WHY extraction. */
@@ -138,7 +139,7 @@ export async function runWhyExtraction(
     });
     diagnostics.aiUsed = true;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = isError(error) ? error.message : String(error);
     if (cli.failOnLlmError) {
       throw new LlmError(`WHY extraction failed: ${message}`);
     }

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -18,7 +18,7 @@ import {
   buildClassificationPrompt,
   classifyTitlesWithFallback,
 } from '@/providers/classification.js';
-import { isRecord, isString } from '@/utils/is.js';
+import { isArray, isRecord, isString } from '@/utils/is.js';
 import type { CategoryMap } from '@/types/changelog.js';
 import {
   buildWhyExtractionPrompt,
@@ -37,7 +37,7 @@ const SYSTEM_ANTHROPIC_CLASSIFY =
  */
 function extractAnthropicClassificationResponse(json: unknown): string {
   // Prefer structured tool_use output when present.
-  if (isRecord(json) && Array.isArray(json.content)) {
+  if (isRecord(json) && isArray(json.content)) {
     const first = json.content[0];
     // tool_use content: { type: 'tool_use', name, input: {...} }
     if (isRecord(first) && first.type === 'tool_use' && isRecord(first.input)) {

--- a/src/providers/classification.ts
+++ b/src/providers/classification.ts
@@ -1,7 +1,9 @@
 import { SECTION_CHORE, SECTION_ORDER } from '@/constants/changelog.js';
 import type { CategoryMap } from '@/types/changelog.js';
 import type { ClassifyTitlesOptions } from '@/types/provider.js';
-import { isRecord, isString } from '@/utils/is.js';
+import { arrayOf, isRecord, isString } from '@/utils/is.js';
+
+const isStringArray = arrayOf(isString);
 
 /** Prompt payload sent to classification LLMs. */
 export type ClassificationPrompt = {
@@ -45,8 +47,8 @@ export function parseCategoryMap(rawJson: string): CategoryMap | undefined {
 
     const result: CategoryMap = {};
     for (const [category, titles] of Object.entries(parsed)) {
-      if (Array.isArray(titles) && titles.every(isString)) {
-        result[category] = titles.slice();
+      if (isStringArray(titles)) {
+        result[category] = [...titles];
       }
     }
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -13,7 +13,7 @@ import {
   LLM_TEMPERATURE_DEFAULT,
   LLM_REASONING_EFFORT,
 } from '@/constants/prompt.js';
-import { isReasoningModel, isRecord, isString } from '@/utils/is.js';
+import { isArray, isReasoningModel, isRecord, isString } from '@/utils/is.js';
 import { PROVIDER_OPENAI } from '@/constants/provider.js';
 import { RELEASE_NOTES_SYSTEM_PROMPT } from '@/constants/system-prompts.js';
 import {
@@ -52,7 +52,7 @@ const SYSTEM_OPENAI_CLASSIFY =
 function extractOpenAiClassificationResponse(json: unknown): string {
   if (
     isRecord(json) &&
-    Array.isArray(json.choices) &&
+    isArray(json.choices) &&
     isRecord(json.choices[0]) &&
     isRecord(json.choices[0].message) &&
     isString(json.choices[0].message.content)

--- a/src/utils/category-score-heuristics.ts
+++ b/src/utils/category-score-heuristics.ts
@@ -38,6 +38,7 @@ import {
   VERSION_FROM_TO_RE,
 } from '@/constants/scoring.js';
 import type { BucketName, CategoryScores } from '@/types/changelog.js';
+import { isNaN } from '@/utils/is.js';
 
 type ScoreDeltas = Partial<Record<BucketName, number>>;
 
@@ -171,8 +172,8 @@ export function applyDependencyBumpHeuristic(
   const fromMajorVersion = parseInt(versionRangeMatch[1], 10);
   const toMajorVersion = parseInt(versionRangeMatch[2], 10);
   if (
-    !Number.isNaN(fromMajorVersion) &&
-    !Number.isNaN(toMajorVersion) &&
+    !isNaN(fromMajorVersion) &&
+    !isNaN(toMajorVersion) &&
     toMajorVersion > fromMajorVersion
   ) {
     scores[SECTION_BREAKING_CHANGES] += WEIGHT_LEVEL.low;

--- a/src/utils/category-score-keywords.ts
+++ b/src/utils/category-score-keywords.ts
@@ -16,6 +16,7 @@ import {
   type WeightedKeyword,
 } from '@/constants/category-scoring.js';
 import type { BucketName } from '@/types/changelog.js';
+import { isString } from '@/utils/is.js';
 
 type ScoreDeltas = Partial<Record<BucketName, number>>;
 
@@ -27,10 +28,9 @@ function addKeywordToIndex(
   entry: WeightedKeyword,
   defaultWeight: number,
 ): void {
-  const { keyword, weight } =
-    typeof entry === 'string'
-      ? { keyword: entry, weight: defaultWeight }
-      : entry;
+  const { keyword, weight } = isString(entry)
+    ? { keyword: entry, weight: defaultWeight }
+    : entry;
   const existingEntries = index.get(keyword) || [];
   existingEntries.push({ section, weight });
   index.set(keyword, existingEntries);

--- a/src/utils/category-tune.ts
+++ b/src/utils/category-tune.ts
@@ -25,7 +25,7 @@ import {
   SCORE_THRESHOLDS,
 } from '@/utils/category-score.js';
 import { isDependencyUpdateTitle } from '@/utils/dependency-update.js';
-import { isBucketName } from '@/utils/is.js';
+import { isArray, isBucketName } from '@/utils/is.js';
 
 const TYPE_INTENT_INDICATORS = [
   'type',
@@ -108,7 +108,7 @@ function collectKnownTitles(
   }
 
   for (const list of Object.values(categories)) {
-    if (!Array.isArray(list)) continue;
+    if (!isArray(list)) continue;
     for (const title of list) {
       knownTitles.add(title);
     }
@@ -121,7 +121,7 @@ function cloneCategoryMap(categories: CategoryMap): CategoryMap {
   const adjusted: CategoryMap = Object.fromEntries(
     Object.entries(categories).map(([section, list]) => [
       section,
-      Array.isArray(list) ? list.slice() : [],
+      isArray(list) ? list.slice() : [],
     ]),
   );
 
@@ -142,11 +142,11 @@ function moveTitlesToCategory(
   titles: string[],
   targetCategory: BucketName,
 ): void {
-  if (!Array.isArray(adjusted[targetCategory])) adjusted[targetCategory] = [];
+  if (!isArray(adjusted[targetCategory])) adjusted[targetCategory] = [];
   const target = adjusted[targetCategory];
   for (const title of titles) {
     for (const list of Object.values(adjusted)) {
-      if (!Array.isArray(list)) continue;
+      if (!isArray(list)) continue;
       const titleIndex = list.indexOf(title);
       if (titleIndex !== -1) list.splice(titleIndex, 1);
     }
@@ -166,7 +166,7 @@ function findCategory(
   title: string,
 ): BucketName | undefined {
   for (const [section, list] of Object.entries(categories)) {
-    if (Array.isArray(list) && list.includes(title) && isBucketName(section)) {
+    if (isArray(list) && list.includes(title) && isBucketName(section)) {
       return section;
     }
   }

--- a/src/utils/classify.ts
+++ b/src/utils/classify.ts
@@ -7,6 +7,7 @@ import type { CategoryMap } from '@/types/changelog.js';
 import type { Provider } from '@/types/provider.js';
 import { fallbackCategoryMap } from '@/providers/classification.js';
 import { providerFactory } from '@/utils/provider.js';
+import { isString } from '@/utils/is.js';
 
 function providerFromConfig(
   providerName: ProviderName,
@@ -36,7 +37,7 @@ export async function classifyTitles(
   config?: ProviderRuntimeConfig,
 ): Promise<CategoryMap> {
   if (!titles.length) return {};
-  if (typeof provider !== 'string') {
+  if (!isString(provider)) {
     return provider.classifyTitles(titles);
   }
   if (!config) {

--- a/src/utils/conventional.ts
+++ b/src/utils/conventional.ts
@@ -1,3 +1,5 @@
+import { isArray } from '@/utils/is.js';
+
 /**
  * Build a flexible conventional prefix regex that accepts optional scope and
  * optional breaking marker `!` before the colon.
@@ -7,7 +9,7 @@
  * @returns Case-insensitive RegExp matching the conventional prefix portion.
  */
 export function flexPrefixRe(types: string | string[]): RegExp {
-  const body = Array.isArray(types) ? types.join('|') : types;
+  const body = isArray(types) ? types.join('|') : types;
   // Matches: "type!:", "type(scope):", "type(scope)!:" (no space between type and scope)
   // Pattern: ^(type)(!:|(\(scope\))?:|(\(scope\))!:) with non-capturing alternation for scope and breaking marker
   return new RegExp(`^(${body})(?:!:|(?:\\([^)]*\\))?!?:)`, 'i');

--- a/src/utils/github-auth.ts
+++ b/src/utils/github-auth.ts
@@ -16,6 +16,7 @@ import type { GitHubRuntimeConfig } from '@/types/config.js';
 import type { GitHubAuth } from '@/types/github.js';
 import { base64url } from '@/utils/base64url.js';
 import { MS_PER_SECOND } from '@/constants/time.js';
+import { isError } from '@/utils/is.js';
 
 /**
  * Normalize private key: allow either multiline PEM or single-line with \n.
@@ -53,7 +54,7 @@ function createAppJwt(appId: string, privateKey: string): string {
   try {
     signature = signer.sign(privateKey);
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = isError(err) ? err.message : String(err);
     // Provide actionable hints for common PEM decoding issues.
     throw new Error(
       `Failed to sign GitHub App JWT with provided private key: ${msg}. ` +

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,5 +1,6 @@
 import type { HttpError } from '@/types/http.js';
 import { safeJsonParse } from '@/utils/json.js';
+import { isUndefined } from '@/utils/is.js';
 
 /**
  * Build a rich HttpError instance containing status code and parsed body details.
@@ -38,7 +39,7 @@ async function parseJsonResponse<T>(
   }
 
   const data = safeJsonParse<T>(text);
-  if (data === undefined) {
+  if (isUndefined(data)) {
     throw new Error(`${errorPrefix} failed to parse JSON response`);
   }
   return data;

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,22 +1,58 @@
 import {
-  isString,
-  isNull,
-  isObject,
+  arrayOf,
   define,
-  isPrimitive,
+  isArray,
+  isError,
+  isInstanceOf as createInstanceGuard,
+  isNaN,
+  isNull,
   isNumber,
+  isObject,
+  isPrimitive,
+  isSafeInteger,
+  isString,
+  isUndefined,
+  oneOf,
+  type Guard,
 } from 'is-kit';
 import { SECTION_ORDER } from '@/constants/changelog.js';
 import type { BucketName } from '@/types/changelog.js';
 
-export { isString, isNumber, isNull, isPrimitive };
+export {
+  arrayOf,
+  isArray,
+  isError,
+  isNaN,
+  isNull,
+  isNumber,
+  isPrimitive,
+  isSafeInteger,
+  isString,
+  isUndefined,
+};
+
+/**
+ * Create a guard for instances of a constructor.
+ * WHY: is-kit 1.6 types constructor parameters as `unknown[]`, which rejects
+ * ordinary constructors under strict function variance even though runtime
+ * instance checks do not invoke the constructor.
+ * @param constructor Class constructor used for the instance check.
+ * @returns Guard narrowing values to the constructor's instance type.
+ */
+export function isInstanceOf<Instance>(
+  constructor: abstract new (...args: never[]) => Instance,
+): Guard<Instance> {
+  return createInstanceGuard(
+    constructor as unknown as abstract new (...args: unknown[]) => Instance,
+  );
+}
 
 /**
  * Determine whether a value is null or undefined.
  * @param value Unknown candidate.
  * @returns True when the value is nullish (null or undefined).
  */
-export const isNullable = define<null | undefined>((value) => value == null);
+export const isNullable = oneOf(isNull, isUndefined);
 
 /**
  * Determine whether a value is a plain object record (non-null object).
@@ -55,6 +91,5 @@ export function isBulletLine(line: string): boolean {
  */
 export const isBucketName = define<BucketName>(
   (section) =>
-    typeof section === 'string' &&
-    (SECTION_ORDER as readonly string[]).includes(section),
+    isString(section) && (SECTION_ORDER as readonly string[]).includes(section),
 );

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,35 +1,66 @@
 import {
-  arrayOf,
+  arrayOf as createArrayOfGuard,
   define,
-  isArray,
-  isError,
+  isArray as isArrayValue,
+  isError as isErrorValue,
   isInstanceOf as createInstanceGuard,
-  isNaN,
+  isNaN as isNaNValue,
   isNull,
   isNumber,
   isObject,
   isPrimitive,
-  isSafeInteger,
+  isSafeInteger as isSafeIntegerValue,
   isString,
-  isUndefined,
+  isUndefined as isUndefinedValue,
   oneOf,
   type Guard,
 } from 'is-kit';
 import { SECTION_ORDER } from '@/constants/changelog.js';
 import type { BucketName } from '@/types/changelog.js';
 
-export {
-  arrayOf,
-  isArray,
-  isError,
-  isNaN,
-  isNull,
-  isNumber,
-  isPrimitive,
-  isSafeInteger,
-  isString,
-  isUndefined,
-};
+export { isNull, isNumber, isPrimitive, isString };
+
+/**
+ * Create a guard that accepts arrays whose elements all satisfy a guard.
+ * @param elementGuard Guard applied to every array element.
+ * @returns Guard narrowing unknown values to a readonly array of guarded elements.
+ */
+export const arrayOf = createArrayOfGuard;
+
+/**
+ * Determine whether a value is an array.
+ * @param value Unknown candidate.
+ * @returns True when the value is an array, narrowing it to a readonly unknown array.
+ */
+export const isArray = isArrayValue;
+
+/**
+ * Determine whether a value represents an Error object.
+ * @param value Unknown candidate.
+ * @returns True for Error instances or values with the built-in Error object tag.
+ */
+export const isError = isErrorValue;
+
+/**
+ * Determine whether a value is the numeric NaN value without coercion.
+ * @param value Unknown candidate.
+ * @returns True only for NaN, narrowing the value to number.
+ */
+export const isNaN = isNaNValue;
+
+/**
+ * Determine whether a value is an integer within JavaScript's safe range.
+ * @param value Unknown candidate.
+ * @returns True for safe integer numbers, narrowing the value to number.
+ */
+export const isSafeInteger = isSafeIntegerValue;
+
+/**
+ * Determine whether a value is exactly undefined.
+ * @param value Unknown candidate.
+ * @returns True only for undefined, narrowing the value accordingly.
+ */
+export const isUndefined = isUndefinedValue;
 
 /**
  * Create a guard for instances of a constructor.

--- a/src/utils/json-extract.ts
+++ b/src/utils/json-extract.ts
@@ -1,4 +1,5 @@
 import { safeJsonParse } from '@/utils/json.js';
+import { isUndefined } from '@/utils/is.js';
 
 /**
  * Extract a JSON object from raw LLM text which might include prose around it.
@@ -9,7 +10,7 @@ import { safeJsonParse } from '@/utils/json.js';
  */
 export function extractJsonObject<T = unknown>(rawText: string): T {
   const directParse = safeJsonParse<T>(rawText);
-  if (directParse !== undefined) {
+  if (!isUndefined(directParse)) {
     return directParse;
   }
 
@@ -20,7 +21,7 @@ export function extractJsonObject<T = unknown>(rawText: string): T {
 
   for (const attemptParse of strategies) {
     const parsed = attemptParse(rawText);
-    if (parsed !== undefined) return parsed;
+    if (!isUndefined(parsed)) return parsed;
   }
 
   throw new Error('Failed to parse JSON from model output');
@@ -67,7 +68,7 @@ function tryParseBalancedObject<T>(text: string): T | undefined {
     const startIndex = braceStack.pop()!;
     const candidate = safeJsonParse<T>(text.slice(startIndex, index + 1));
 
-    if (candidate === undefined) {
+    if (isUndefined(candidate)) {
       continue;
     }
 

--- a/src/utils/llm-output-model.ts
+++ b/src/utils/llm-output-model.ts
@@ -19,6 +19,7 @@ import {
   buildAutoPrBody,
 } from '@/utils/llm-output-common.js';
 import { LlmError } from '@/lib/errors.js';
+import { isError } from '@/utils/is.js';
 
 function buildLogsForLLM(
   commitList: CommitLite[],
@@ -87,9 +88,11 @@ export async function buildOutputFromModelOrFallback(
       llm = await parseOrRetryLLMOutput(provider, llmInput);
       aiUsed = true;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = isError(err) ? err.message : String(err);
       if (failOnLlmError) {
-        throw err instanceof Error ? err : new LlmError(`LLM generation failed: ${message}`);
+        throw isError(err)
+          ? err
+          : new LlmError(`LLM generation failed: ${message}`);
       }
       fallbackReasons.push(`LLM generation failed: ${message}`);
     }

--- a/src/utils/llm-output-release-notes.ts
+++ b/src/utils/llm-output-release-notes.ts
@@ -24,6 +24,7 @@ import {
   buildPrUrl,
   resolvePrFromTitles,
 } from '@/utils/llm-output-common.js';
+import { isError } from '@/utils/is.js';
 
 /**
  * Fill missing PR numbers/URLs/authors for release note items when possible.
@@ -138,7 +139,7 @@ export async function buildOutputFromReleaseNotes(
         // Mark AI usage only when classification had input and a provider key is available.
         aiUsed = aiUsed || hasProviderKey;
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = isError(err) ? err.message : String(err);
         if (failOnLlmError) {
           throw new LlmError(`LLM classification failed: ${message}`);
         }

--- a/src/utils/llm-parse.ts
+++ b/src/utils/llm-parse.ts
@@ -3,6 +3,7 @@ import type { LLMInput, LLMOutput } from '@/types/llm.js';
 import { LLMOutputSchema } from '@/schema/schema.js';
 import { LlmError, ValidationError } from '@/lib/errors.js';
 import { LLM_TRUNCATE_LIMIT } from '@/constants/prompt.js';
+import { isError } from '@/utils/is.js';
 
 /**
  * Generate LLM output and enforce schema with a bounded retry using a repaired prompt.
@@ -43,7 +44,7 @@ export async function parseOrRetryLLMOutput(
   if (lastWasProviderError) {
     // Wrap provider errors for clearer upstream handling after retries.
     throw new LlmError(
-      lastErr instanceof Error ? lastErr.message : 'Unknown LLM provider error',
+      isError(lastErr) ? lastErr.message : 'Unknown LLM provider error',
     );
   }
   throw new ValidationError('LLM output did not match schema after retry');

--- a/src/utils/output-json-schema.ts
+++ b/src/utils/output-json-schema.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 import { LLMOutputSchema } from '@/schema/schema.js';
+import { isInstanceOf } from '@/utils/is.js';
+
+const isZodArray = isInstanceOf(z.ZodArray);
+const isZodDefault = isInstanceOf(z.ZodDefault);
+const isZodOptional = isInstanceOf(z.ZodOptional);
+const isZodString = isInstanceOf(z.ZodString);
 
 /**
  * Recursively unwrap optional/default wrappers to reach the inner schema.
@@ -7,9 +13,9 @@ import { LLMOutputSchema } from '@/schema/schema.js';
  * @returns Inner non-optional schema.
  */
 function unwrapOptional(schema: z.ZodTypeAny): z.ZodTypeAny {
-  if (schema instanceof z.ZodDefault)
+  if (isZodDefault(schema))
     return unwrapOptional(schema.unwrap() as z.ZodTypeAny);
-  if (schema instanceof z.ZodOptional)
+  if (isZodOptional(schema))
     return unwrapOptional(schema.unwrap() as z.ZodTypeAny);
   return schema;
 }
@@ -19,7 +25,7 @@ function unwrapOptional(schema: z.ZodTypeAny): z.ZodTypeAny {
  * @param schema Zod schema to inspect.
  */
 function isOptionalSchema(schema: z.ZodTypeAny): boolean {
-  return schema instanceof z.ZodOptional || schema instanceof z.ZodDefault;
+  return isZodOptional(schema) || isZodDefault(schema);
 }
 
 /**
@@ -29,7 +35,7 @@ function isOptionalSchema(schema: z.ZodTypeAny): boolean {
  */
 function buildJsonSchemaForArray(schema: z.ZodArray): unknown {
   const inner = unwrapOptional(schema.element as z.ZodTypeAny);
-  if (inner instanceof z.ZodString) {
+  if (isZodString(inner)) {
     return { type: 'array', items: { type: 'string' } };
   }
   return {}; // unknown array element type, stay permissive
@@ -42,8 +48,8 @@ function buildJsonSchemaForArray(schema: z.ZodArray): unknown {
  */
 function buildJsonSchemaForProperty(schema: z.ZodTypeAny): unknown {
   const core = unwrapOptional(schema);
-  if (core instanceof z.ZodString) return { type: 'string' };
-  if (core instanceof z.ZodArray) return buildJsonSchemaForArray(core);
+  if (isZodString(core)) return { type: 'string' };
+  if (isZodArray(core)) return buildJsonSchemaForArray(core);
   return {}; // default to loose typing when structure is unfamiliar
 }
 

--- a/src/utils/title-lookup.ts
+++ b/src/utils/title-lookup.ts
@@ -2,6 +2,7 @@ import {
   normalizeTitle,
   stripConventionalPrefix,
 } from '@/utils/title-normalize.js';
+import { isUndefined } from '@/utils/is.js';
 
 /** Case-insensitive and normalized title lookup tables. */
 export type TitleLookup<Value> = {
@@ -72,20 +73,20 @@ export function buildTitleLookup<Value>(
       if (!normalizedTitle) continue;
 
       const existingValue = normalized.get(normalizedTitle);
-      if (existingValue !== undefined && options.onNormalizedCollision) {
+      if (!isUndefined(existingValue) && options.onNormalizedCollision) {
         const resolvedValue = options.onNormalizedCollision({
           title,
           normalizedTitle,
           existingValue,
           incomingValue: entry.value,
         });
-        if (resolvedValue !== undefined) {
+        if (!isUndefined(resolvedValue)) {
           normalized.set(normalizedTitle, resolvedValue);
         }
         continue;
       }
 
-      if (existingValue === undefined) {
+      if (isUndefined(existingValue)) {
         normalized.set(normalizedTitle, entry.value);
       }
     }
@@ -114,12 +115,12 @@ export function findTitleMatch<Value>(
     // normalized hits must win over direct-key matches to keep lookups stable
     // across punctuation, casing, and conventional-prefix variants.
     const exactMatch = lookup.normalized.get(normalizedTitle);
-    if (exactMatch !== undefined) return exactMatch;
+    if (!isUndefined(exactMatch)) return exactMatch;
   }
 
   for (const key of buildDirectKeys(title)) {
     const directMatch = lookup.direct.get(key);
-    if (directMatch !== undefined) return directMatch;
+    if (!isUndefined(directMatch)) return directMatch;
   }
 
   if (!normalizedTitle) return undefined;

--- a/src/utils/why-candidates.ts
+++ b/src/utils/why-candidates.ts
@@ -3,6 +3,7 @@ import {
   type WhyCanonicalSectionName,
 } from '@/constants/why-section-aliases.js';
 import { escapeRegExp } from '@/utils/escape.js';
+import { isUndefined } from '@/utils/is.js';
 
 const TARGET_SECTION_LABEL_PATTERN = Array.from(WHY_SECTION_ALIASES.keys())
   .sort((left, right) => right.length - left.length)
@@ -94,14 +95,14 @@ function isTemplateFieldLabel(line: string): boolean {
 
 function isTargetLabelBlock(line: string): boolean {
   const labelMatch = line.match(TARGET_SECTION_LABEL_ONLY_RE);
-  return (
-    canonicalTargetSectionName(labelMatch?.groups?.name ?? '') !== undefined
+  return !isUndefined(
+    canonicalTargetSectionName(labelMatch?.groups?.name ?? ''),
   );
 }
 
 function isInlineTargetLabel(line: string): boolean {
   const match = line.match(TARGET_INLINE_LABEL_RE);
-  return canonicalTargetSectionName(match?.groups?.name ?? '') !== undefined;
+  return !isUndefined(canonicalTargetSectionName(match?.groups?.name ?? ''));
 }
 
 function extractInlineTargetLabel(line: string): ExtractedSection | undefined {
@@ -172,10 +173,9 @@ export function extractWhyTargetSections(body: string): ExtractedSections {
 
     hasTargetSection = true;
     const startIndex = (match.index ?? 0) + match[0].length;
-    const endIndex =
-      headingMatches[matchIndex + 1]?.index === undefined
-        ? body.length
-        : headingMatches[matchIndex + 1].index;
+    const endIndex = isUndefined(headingMatches[matchIndex + 1]?.index)
+      ? body.length
+      : headingMatches[matchIndex + 1].index;
     const text = body.slice(startIndex, endIndex).trim();
     if (!text) continue;
 

--- a/src/utils/why-pr-reference.ts
+++ b/src/utils/why-pr-reference.ts
@@ -1,3 +1,5 @@
+import { isSafeInteger } from '@/utils/is.js';
+
 const PULL_URL_PR_NUMBER_RE =
   /\b(?<pullUrl>https?:\/\/[^\s)]+\/pull\/(?<prNumber>\d+)\b)/gi;
 const PULL_LINK_SUFFIX_RE =
@@ -70,7 +72,7 @@ function isCurrentRepositoryPullUrl(
 function parsePrNumber(rawNumber: string | undefined): number | null {
   if (!rawNumber) return null;
   const prNumber = Number.parseInt(rawNumber, 10);
-  return Number.isSafeInteger(prNumber) ? prNumber : null;
+  return isSafeInteger(prNumber) ? prNumber : null;
 }
 
 function extractOwningPrReference(


### PR DESCRIPTION
## Summary

Standardize runtime type guards with `is-kit`.

<!-- A brief summary of the changes -->

## Description

- replace handwritten runtime type checks with `is-kit` guards across `src`
- consolidate reusable guards and constructor compatibility handling in `src/utils/is.ts`
- combine array and element validation with guards such as `arrayOf(isString)`

<!-- A detailed explanation of the changes, including why they are needed -->
