### PR TITLE
refactor: separate changelog run phase

### DIFF
--- a/src/lib/changelog-run-input.ts
+++ b/src/lib/changelog-run-input.ts
@@ -1,0 +1,144 @@
+import type { CliOptions } from '@/schema/cli.js';
+import type { AppConfig, ProviderRuntimeConfig } from '@/types/config.js';
+import type { CommitLite } from '@/types/commit.js';
+import type { PullRef } from '@/types/github.js';
+import type { Provider } from '@/types/provider.js';
+import type { CustomInstructionsResolution } from '@/lib/customization.js';
+import type { ChangelogRunDependencies } from '@/lib/changelog-run-dependencies.js';
+import type { ReleasePlan } from '@/lib/release-context.js';
+import {
+  resolvePullRequestsBySha,
+  resolveReleaseBody,
+} from '@/lib/release-data.js';
+
+/** Git, GitHub, configuration, and customization inputs for generation. */
+export type ChangelogRunInput = {
+  /** Selected provider adapter. */
+  provider: Provider;
+  /** Normalized release metadata. */
+  releasePlan: ReleasePlan;
+  /** Merge-commit log used by deterministic fallback generation. */
+  mergedPullRequests: string;
+  /** Existing changelog with the current version link removed. */
+  existingChangelog: string;
+  /** Commits included in the release range. */
+  commitList: CommitLite[];
+  /** GitHub token, when authentication is available. */
+  token?: string;
+  /** Whether the selected provider has an API key. */
+  hasProviderKey: boolean;
+  /** Pull request metadata keyed by commit SHA. */
+  pullRequestsBySha: Record<string, PullRef[]>;
+  /** Release notes resolved from CLI input or GitHub. */
+  releaseBody: string;
+  /** Pull request numbers keyed by commit SHA. */
+  prNumbersBySha: Record<string, number[]>;
+  /** Pull request numbers keyed by normalized title. */
+  titleToPr: Record<string, number>;
+  /** Prompt customization text and diagnostics. */
+  customInstructionsResolution: CustomInstructionsResolution;
+  /** Runtime settings for the selected provider. */
+  providerConfig: ProviderRuntimeConfig;
+};
+
+/** Parameters used to collect one changelog run's generation inputs. */
+export type ResolveChangelogRunInputParams = {
+  /** Validated CLI options. */
+  cli: CliOptions;
+  /** Runtime configuration resolved for this process. */
+  appConfig: AppConfig;
+  /** Shell, GitHub, and transformation adapters. */
+  deps: ChangelogRunDependencies;
+};
+
+/**
+ * Collect release data and configuration needed to generate a changelog.
+ * WHY: Keeping input resolution separate from generation makes the workflow
+ * phases explicit and prevents network and filesystem concerns from spreading
+ * through the output orchestration.
+ * @param params CLI options, runtime configuration, and workflow adapters.
+ * @returns Fully resolved input for changelog generation.
+ */
+export async function resolveChangelogRunInput({
+  cli,
+  appConfig,
+  deps,
+}: ResolveChangelogRunInputParams): Promise<ChangelogRunInput> {
+  const provider = deps.providerFactory(cli.provider, appConfig.providers);
+  const releasePlan = deps.resolveReleasePlan(
+    cli,
+    deps.getRepoFullName(appConfig),
+  );
+  const { owner, repo, repoPath, changelogPath, releaseRef, version, prevRef } =
+    releasePlan;
+
+  const mergedPullRequests = deps.gitMergedPRs(prevRef, releaseRef, repoPath);
+  const existingChangelog = deps.prepareExistingChangelog(
+    changelogPath,
+    version,
+  );
+  const commitList = deps.commitsInRange(prevRef, releaseRef, repoPath);
+  const { token, hasProviderKey } = await deps.resolveRunCredentials(
+    provider.name,
+    owner,
+    repo,
+    appConfig,
+  );
+
+  // WHY: These GitHub lookups depend on the same resolved credentials but not
+  // on each other, so running them together avoids unnecessary network latency.
+  const [pullRequestsBySha, releaseBody] = await Promise.all([
+    resolvePullRequestsBySha({
+      deps,
+      owner,
+      repo,
+      releaseRef,
+      repoPath,
+      token,
+      githubApiBase: appConfig.github.apiBase,
+      commitList,
+    }),
+    resolveReleaseBody({
+      cli,
+      deps,
+      owner,
+      repo,
+      token,
+      githubApiBase: appConfig.github.apiBase,
+    }),
+  ]);
+
+  const prNumbersBySha = deps.buildPrMapBySha({
+    commitList,
+    prsLog: mergedPullRequests,
+    repoPath,
+    apiPrMap: pullRequestsBySha,
+  });
+  const titleToPr = deps.buildTitleToPr(
+    commitList,
+    mergedPullRequests,
+    prNumbersBySha,
+  );
+  const customInstructionsResolution =
+    deps.resolveCustomInstructionsWithDiagnostics({
+      instructions: cli.instructions,
+      instructionsFile: cli.instructionsFile,
+      repoPath,
+    });
+
+  return {
+    provider,
+    releasePlan,
+    mergedPullRequests,
+    existingChangelog,
+    commitList,
+    token,
+    hasProviderKey,
+    pullRequestsBySha,
+    releaseBody,
+    prNumbersBySha,
+    titleToPr,
+    customInstructionsResolution,
+    providerConfig: deps.getProviderRuntimeConfig(appConfig, provider.name),
+  };
+}

--- a/src/lib/changelog-run-output.ts
+++ b/src/lib/changelog-run-output.ts
@@ -1,0 +1,99 @@
+import type { CliOptions } from '@/schema/cli.js';
+import type { LLMOutput } from '@/types/llm.js';
+import type { Provider } from '@/types/provider.js';
+import type { WhyDiagnostics } from '@/types/why.js';
+import type { ChangelogRunDependencies } from '@/lib/changelog-run-dependencies.js';
+
+type ChangelogRunOutputDependencies = Pick<
+  ChangelogRunDependencies,
+  'fetchPRDetails' | 'finalizeChangelogUpdate' | 'runWhyExtraction'
+>;
+
+/** Parameters used to finalize and optionally enrich generated output. */
+export type FinalizeChangelogRunOutputParams = {
+  /** Validated CLI options controlling WHY extraction. */
+  cli: CliOptions;
+  /** Initial generated changelog and pull request payload. */
+  llm: LLMOutput;
+  /** Selected provider adapter. */
+  provider: Provider;
+  /** Whether the selected provider has an API key. */
+  hasProviderKey: boolean;
+  /** Repository owner or organization. */
+  owner: string;
+  /** Repository name. */
+  repo: string;
+  /** Previous release ref or first commit. */
+  prevRef: string;
+  /** Current release ref or tag. */
+  releaseRef: string;
+  /** Release version without the leading `v`. */
+  version: string;
+  /** Existing changelog content before the update. */
+  existingChangelog: string;
+  /** Pull request numbers keyed by normalized title. */
+  titleToPr: Record<string, number>;
+  /** GitHub token, when authentication is available. */
+  token?: string;
+  /** GitHub or GHES API base URL. */
+  githubApiBase: string;
+  /** Output finalization and WHY extraction adapters. */
+  deps: ChangelogRunOutputDependencies;
+};
+
+/** Final changelog artifacts and enrichment diagnostics. */
+export type FinalizeChangelogRunOutputResult = {
+  /** Sanitized LLM output after optional WHY enrichment. */
+  llm: LLMOutput;
+  /** Updated full changelog content. */
+  updatedChangelog: string;
+  /** Diagnostics from optional WHY extraction. */
+  whyDiagnostics: WhyDiagnostics;
+};
+
+/**
+ * Finalize generated output and re-finalize only when WHY enrichment changes it.
+ * WHY: WHY notes alter section markdown after normal post-processing. Running
+ * finalization again preserves compare links and PR references without doing
+ * duplicate work when enrichment is disabled or produces no change.
+ * @param params Generated output, release context, and workflow adapters.
+ * @returns Final LLM payload, full changelog content, and WHY diagnostics.
+ */
+export async function finalizeChangelogRunOutput(
+  params: FinalizeChangelogRunOutputParams,
+): Promise<FinalizeChangelogRunOutputResult> {
+  const finalize = (llm: LLMOutput) =>
+    params.deps.finalizeChangelogUpdate({
+      owner: params.owner,
+      repo: params.repo,
+      version: params.version,
+      prevRef: params.prevRef,
+      releaseRef: params.releaseRef,
+      existing: params.existingChangelog,
+      llm,
+      titleToPr: params.titleToPr,
+    });
+
+  let finalized = finalize(params.llm);
+  const whyOutput = await params.deps.runWhyExtraction({
+    cli: params.cli,
+    llm: finalized.llm,
+    provider: params.provider,
+    hasProviderKey: params.hasProviderKey,
+    owner: params.owner,
+    repo: params.repo,
+    token: params.token,
+    githubApiBase: params.githubApiBase,
+    fetchPRDetails: params.deps.fetchPRDetails,
+  });
+
+  if (whyOutput.llm !== finalized.llm) {
+    finalized = finalize(whyOutput.llm);
+  }
+
+  return {
+    llm: finalized.llm,
+    updatedChangelog: finalized.updated,
+    whyDiagnostics: whyOutput.diagnostics,
+  };
+}

--- a/src/lib/changelog-run.ts
+++ b/src/lib/changelog-run.ts
@@ -10,13 +10,11 @@ import {
   type ChangelogRunDependencies,
 } from '@/lib/changelog-run-dependencies.js';
 import {
-  resolvePullRequestsBySha,
-  resolveReleaseBody,
-} from '@/lib/release-data.js';
-import {
   writeDryRunOutput,
   type ChangelogRunLogger,
 } from '@/lib/changelog-dry-run.js';
+import { resolveChangelogRunInput } from '@/lib/changelog-run-input.js';
+import { finalizeChangelogRunOutput } from '@/lib/changelog-run-output.js';
 
 export type { ChangelogRunDependencies, ChangelogRunLogger };
 
@@ -35,65 +33,28 @@ export async function executeChangelogRun(params: {
 }): Promise<void> {
   const { cli, appConfig, log = console.log } = params;
   const deps = resolveChangelogRunDependencies(params.deps);
-  const provider = deps.providerFactory(cli.provider, appConfig.providers);
   const {
-    owner,
-    repo,
-    repoPath,
-    changelogPath,
-    releaseRef,
-    version,
-    prevRef,
-    date,
-  } = deps.resolveReleasePlan(cli, deps.getRepoFullName(appConfig));
-
-  const prs = deps.gitMergedPRs(prevRef, releaseRef, repoPath);
-  const existing = deps.prepareExistingChangelog(changelogPath, version);
-  const commitList = deps.commitsInRange(prevRef, releaseRef, repoPath);
-
-  const { token, hasProviderKey } = await deps.resolveRunCredentials(
-    provider.name,
-    owner,
-    repo,
-    appConfig,
-  );
-  const apiPrMap = await resolvePullRequestsBySha({
-    deps,
-    owner,
-    repo,
-    releaseRef,
-    repoPath,
-    token,
-    githubApiBase: appConfig.github.apiBase,
+    provider,
+    releasePlan,
+    mergedPullRequests,
+    existingChangelog,
     commitList,
-  });
-  const releaseBody = await resolveReleaseBody({
+    token,
+    hasProviderKey,
+    pullRequestsBySha,
+    releaseBody,
+    prNumbersBySha,
+    titleToPr,
+    customInstructionsResolution,
+    providerConfig,
+  } = await resolveChangelogRunInput({
     cli,
-    deps,
-    owner,
-    repo,
-    token,
-    githubApiBase: appConfig.github.apiBase,
-  });
-
-  const prMapBySha = deps.buildPrMapBySha({
-    commitList,
-    prsLog: prs,
-    repoPath,
-    apiPrMap,
-  });
-  const titleToPr = deps.buildTitleToPr(commitList, prs, prMapBySha);
-  const customInstructionsResolution =
-    deps.resolveCustomInstructionsWithDiagnostics({
-      instructions: cli.instructions,
-      instructionsFile: cli.instructionsFile,
-      repoPath,
-    });
-  const customInstructions = customInstructionsResolution.instructions;
-  const providerConfig = deps.getProviderRuntimeConfig(
     appConfig,
-    provider.name,
-  );
+    deps,
+  });
+  const { owner, repo, changelogPath, releaseRef, version, prevRef, date } =
+    releasePlan;
+  const customInstructions = customInstructionsResolution.instructions;
   const llmOutput = await deps.buildChangelogLlmOutput({
     owner,
     repo,
@@ -104,11 +65,11 @@ export async function executeChangelogRun(params: {
     releaseBody,
     language: cli.language,
     customInstructions,
-    existingChangelog: existing,
+    existingChangelog,
     commitList,
-    prs,
-    prMapBySha,
-    pullRequestsBySha: apiPrMap,
+    prs: mergedPullRequests,
+    prMapBySha: prNumbersBySha,
+    pullRequestsBySha,
     titleToPr,
     provider,
     providerConfig,
@@ -119,45 +80,23 @@ export async function executeChangelogRun(params: {
     requireProvider: cli.requireProvider,
     failOnLlmError: cli.failOnLlmError,
   });
-  let llm = llmOutput.llm;
-
-  let finalizedUpdate = deps.finalizeChangelogUpdate({
+  const finalizedOutput = await finalizeChangelogRunOutput({
+    cli,
+    llm: llmOutput.llm,
+    provider,
+    hasProviderKey,
     owner,
     repo,
     version,
     prevRef,
     releaseRef,
-    existing,
-    llm,
+    existingChangelog,
     titleToPr,
-  });
-  llm = finalizedUpdate.llm;
-  let updated = finalizedUpdate.updated;
-  const whyOutput = await deps.runWhyExtraction({
-    cli,
-    llm,
-    provider,
-    hasProviderKey,
-    owner,
-    repo,
     token,
     githubApiBase: appConfig.github.apiBase,
-    fetchPRDetails: deps.fetchPRDetails,
+    deps,
   });
-  if (whyOutput.llm !== llm) {
-    finalizedUpdate = deps.finalizeChangelogUpdate({
-      owner,
-      repo,
-      version,
-      prevRef,
-      releaseRef,
-      existing,
-      llm: whyOutput.llm,
-      titleToPr,
-    });
-    llm = finalizedUpdate.llm;
-    updated = finalizedUpdate.updated;
-  }
+  const { llm, updatedChangelog, whyDiagnostics } = finalizedOutput;
 
   if (cli.dryRun) {
     writeDryRunOutput({
@@ -170,8 +109,8 @@ export async function executeChangelogRun(params: {
       customInstructionsResolution,
       customInstructions,
       hasProviderKey,
-      whyDiagnostics: whyOutput.diagnostics,
-      updated,
+      whyDiagnostics,
+      updated: updatedChangelog,
     });
     return;
   }
@@ -179,7 +118,7 @@ export async function executeChangelogRun(params: {
   deps.ensureGithubTokenRequired(cli.dryRun, token);
   const ghToken = token as string;
 
-  deps.writeChangelog(changelogPath, updated);
+  deps.writeChangelog(changelogPath, updatedChangelog);
 
   const branch = `${PR_BRANCH_PREFIX}${version}`;
   const prNum = await deps.createPR({

--- a/tests/lib/changelog-run-output.test.ts
+++ b/tests/lib/changelog-run-output.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { PROVIDER_OPENAI } from '@/constants/provider.js';
+import { finalizeChangelogRunOutput } from '@/lib/changelog-run-output.js';
+import type { ChangelogRunDependencies } from '@/lib/changelog-run.js';
+import type { CliOptions } from '@/schema/cli.js';
+import type { LLMOutput } from '@/types/llm.js';
+import type { Provider } from '@/types/provider.js';
+
+const cli = {
+  repoPath: '.',
+  changelogPath: 'CHANGELOG.md',
+  baseBranch: 'main',
+  provider: PROVIDER_OPENAI,
+  releaseBody: '',
+  language: 'en',
+  dryRun: true,
+  dryRunJsonReport: false,
+  failOnLlmError: false,
+  requireProvider: false,
+  noAi: false,
+  why: true,
+  whyMaxPrs: 30,
+  whyMaxCharsPerPr: 800,
+  whyConfidence: 'medium',
+  whyLabel: 'Why',
+} satisfies CliOptions;
+
+const provider: Provider = {
+  name: PROVIDER_OPENAI,
+  modelName: 'mock-openai',
+  supports: {
+    jsonMode: true,
+    streaming: false,
+    reasoning: false,
+    maxOutputTokens: 1000,
+  },
+  generate: async () => initialLlm,
+  classifyTitles: async () => ({}),
+  extractWhyNotes: async () => ({ items: [] }),
+};
+
+const initialLlm: LLMOutput = {
+  new_section_markdown: 'generated section',
+  pr_title: 'docs(changelog): 1.2.3',
+  pr_body: 'body',
+};
+
+const whyDiagnostics = {
+  enabled: true,
+  aiUsed: true,
+  targetsFound: 1,
+  prBodiesFetched: 1,
+  skippedBeforeFetch: 0,
+  skippedLowTrust: 0,
+  notesRendered: 1,
+  fallbackReasons: [],
+};
+
+describe('finalizeChangelogRunOutput', () => {
+  test('re-finalizes the changelog after WHY enrichment changes output', async () => {
+    const enrichedLlm = {
+      ...initialLlm,
+      new_section_markdown: 'generated section\n\nWhy: useful context',
+    };
+    const finalizeChangelogUpdate = jest.fn<
+      ChangelogRunDependencies['finalizeChangelogUpdate']
+    >((params) => ({
+      llm: params.llm,
+      updated: `updated: ${params.llm.new_section_markdown}`,
+    }));
+    const runWhyExtraction = jest.fn<
+      ChangelogRunDependencies['runWhyExtraction']
+    >(async () => ({ llm: enrichedLlm, diagnostics: whyDiagnostics }));
+
+    const result = await finalizeChangelogRunOutput({
+      cli,
+      llm: initialLlm,
+      provider,
+      hasProviderKey: true,
+      owner: 'octo',
+      repo: 'repo',
+      prevRef: 'v1.2.2',
+      releaseRef: 'v1.2.3',
+      version: '1.2.3',
+      existingChangelog: 'existing changelog',
+      titleToPr: {},
+      token: 'token',
+      githubApiBase: 'https://api.github.com',
+      deps: {
+        finalizeChangelogUpdate,
+        runWhyExtraction,
+        fetchPRDetails: jest.fn<ChangelogRunDependencies['fetchPRDetails']>(
+          async () => null,
+        ),
+      },
+    });
+
+    expect(finalizeChangelogUpdate).toHaveBeenCalledTimes(2);
+    expect(finalizeChangelogUpdate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ llm: enrichedLlm }),
+    );
+    expect(result).toEqual({
+      llm: enrichedLlm,
+      updatedChangelog: `updated: ${enrichedLlm.new_section_markdown}`,
+      whyDiagnostics,
+    });
+  });
+
+  test('keeps the first finalized changelog when WHY extraction is unchanged', async () => {
+    const finalizedLlm = { ...initialLlm };
+    const finalizeChangelogUpdate = jest.fn<
+      ChangelogRunDependencies['finalizeChangelogUpdate']
+    >(() => ({ llm: finalizedLlm, updated: 'updated once' }));
+    const runWhyExtraction = jest.fn<
+      ChangelogRunDependencies['runWhyExtraction']
+    >(async () => ({ llm: finalizedLlm, diagnostics: whyDiagnostics }));
+
+    const result = await finalizeChangelogRunOutput({
+      cli,
+      llm: initialLlm,
+      provider,
+      hasProviderKey: true,
+      owner: 'octo',
+      repo: 'repo',
+      prevRef: 'v1.2.2',
+      releaseRef: 'v1.2.3',
+      version: '1.2.3',
+      existingChangelog: 'existing changelog',
+      titleToPr: {},
+      githubApiBase: 'https://api.github.com',
+      deps: {
+        finalizeChangelogUpdate,
+        runWhyExtraction,
+        fetchPRDetails: jest.fn<ChangelogRunDependencies['fetchPRDetails']>(
+          async () => null,
+        ),
+      },
+    });
+
+    expect(finalizeChangelogUpdate).toHaveBeenCalledTimes(1);
+    expect(result.updatedChangelog).toBe('updated once');
+  });
+});


### PR DESCRIPTION
## Summary

Separate changelog run phase.
<!-- A brief summary of the changes -->

## Description

Separate changelog execution into input-resolution and output-finalization phases. 

This simplifies the main orchestration flow, runs independent GitHub lookups concurrently, and adds coverage for WHY enrichment finalization.

<!-- A detailed explanation of the changes, including why they are needed -->
