### PR TITLE
refactor: introduce canonical release change identity

### DIFF
--- a/src/types/release.ts
+++ b/src/types/release.ts
@@ -12,6 +12,24 @@ export type ReleaseItem = {
   url?: string;
 };
 
+/** Stable identity assigned to a release change before classification. */
+export type ReleaseChangeId =
+  `pr:${number}` | `commit:${string}` | `release-note:${number}`;
+
+/** Source record from which a canonical release change was derived. */
+export type ReleaseChangeOrigin =
+  | { kind: 'pull-request'; number: number }
+  | { kind: 'commit'; sha: string }
+  | { kind: 'release-note'; index: number };
+
+/** Canonical release item with identity independent of its editable title. */
+export type ReleaseChange = ReleaseItem & {
+  /** Stable identifier used to reconcile classification and rendering. */
+  id: ReleaseChangeId;
+  /** Original source used to derive the stable identifier. */
+  origin: ReleaseChangeOrigin;
+};
+
 /** Additional sections surfaced from release notes. */
 export type ReleaseSection = {
   /** Section heading text (e.g., "Breaking Changes"). */

--- a/src/utils/llm-output-release-notes.ts
+++ b/src/utils/llm-output-release-notes.ts
@@ -1,6 +1,7 @@
 import { fetchPRInfo } from '@/lib/github.js';
 import {
   buildReleaseItemsFromPullRequests,
+  identifyReleaseItems,
   parseReleaseNotes,
   buildSectionFromRelease,
 } from '@/utils/release.js';
@@ -25,6 +26,7 @@ import {
   resolvePrFromTitles,
 } from '@/utils/llm-output-common.js';
 import { isError } from '@/utils/is.js';
+import type { ReleaseChange } from '@/types/release.js';
 
 /**
  * Fill missing PR numbers/URLs/authors for release note items when possible.
@@ -36,13 +38,7 @@ async function enrichReleaseItems(params: {
   token?: string;
   githubApiBase: string;
   titleToPr: BuildChangelogLlmOutputParams['titleToPr'];
-  items: Array<{
-    title: string;
-    rawTitle?: string;
-    pr?: number;
-    url?: string;
-    author?: string;
-  }>;
+  items: ReleaseChange[];
 }): Promise<void> {
   const { owner, repo, token, githubApiBase, titleToPr, items } = params;
 
@@ -99,16 +95,17 @@ export async function buildOutputFromReleaseNotes(
   } = params;
 
   const parsedRelease = parseReleaseNotes(releaseBody, { owner, repo });
+  let releaseChanges = identifyReleaseItems(parsedRelease.items);
   let usedPullRequestMetadata = false;
-  if (!parsedRelease.items.length && !parsedRelease.sections?.length) {
-    parsedRelease.items = buildReleaseItemsFromPullRequests(
+  if (!releaseChanges.length && !parsedRelease.sections?.length) {
+    releaseChanges = buildReleaseItemsFromPullRequests(
       params.commitList,
       params.pullRequestsBySha ?? {},
     );
-    usedPullRequestMetadata = parsedRelease.items.length > 0;
+    usedPullRequestMetadata = releaseChanges.length > 0;
   }
   const hasAdditionalSections = Boolean(parsedRelease.sections?.length);
-  if (!parsedRelease.items.length && !hasAdditionalSections) return null;
+  if (!releaseChanges.length && !hasAdditionalSections) return null;
 
   fallbackReasons.push(
     usedPullRequestMetadata
@@ -123,10 +120,10 @@ export async function buildOutputFromReleaseNotes(
     token,
     githubApiBase,
     titleToPr,
-    items: parsedRelease.items,
+    items: releaseChanges,
   });
 
-  const titlesForLLM = buildTitlesForClassification(parsedRelease.items);
+  const titlesForLLM = buildTitlesForClassification(releaseChanges);
   let categories: Record<string, string[]> = {};
   if (titlesForLLM.length) {
     if (noAi) {
@@ -148,13 +145,13 @@ export async function buildOutputFromReleaseNotes(
       }
     }
     // Heuristic tuning: ensure typing/contract corrections are grouped under Fixed.
-    categories = tuneCategoriesByTitle(parsedRelease.items, categories);
+    categories = tuneCategoriesByTitle(releaseChanges, categories);
   }
 
   const section = buildSectionFromRelease({
     version,
     date,
-    items: parsedRelease.items,
+    items: releaseChanges,
     categories,
     fullChangelog: parsedRelease.fullChangelog,
     sections: parsedRelease.sections,

--- a/src/utils/release-items.ts
+++ b/src/utils/release-items.ts
@@ -23,6 +23,12 @@ export function buildReleaseChangeId(
       return `commit:${origin.sha}`;
     case 'release-note':
       return `release-note:${origin.index}`;
+    default: {
+      const exhaustiveOrigin: never = origin;
+      throw new Error(
+        `Unsupported release-change origin: ${JSON.stringify(exhaustiveOrigin)}`,
+      );
+    }
   }
 }
 

--- a/src/utils/release-items.ts
+++ b/src/utils/release-items.ts
@@ -1,7 +1,53 @@
 import type { CommitLite } from '@/types/commit.js';
 import type { PullRef } from '@/types/github.js';
-import type { ReleaseItem } from '@/types/release.js';
+import type {
+  ReleaseChange,
+  ReleaseChangeId,
+  ReleaseChangeOrigin,
+  ReleaseItem,
+} from '@/types/release.js';
 import { stripConventionalPrefix } from '@/utils/title-normalize.js';
+
+/**
+ * Build a stable release-change ID from its source identity.
+ * @param origin Source record for the release change.
+ * @returns Stable ID suitable for provider reconciliation.
+ */
+export function buildReleaseChangeId(
+  origin: ReleaseChangeOrigin,
+): ReleaseChangeId {
+  switch (origin.kind) {
+    case 'pull-request':
+      return `pr:${origin.number}`;
+    case 'commit':
+      return `commit:${origin.sha}`;
+    case 'release-note':
+      return `release-note:${origin.index}`;
+  }
+}
+
+/**
+ * Assign stable identities to items parsed from ordered release notes.
+ * WHY: Display titles may be duplicated or rewritten, so downstream stages
+ * need an identity that does not depend on title matching.
+ * @param items Parsed release-note items in source order.
+ * @returns Canonical release changes with PR- or position-based identities.
+ */
+export function identifyReleaseItems(
+  items: readonly ReleaseItem[],
+): ReleaseChange[] {
+  return items.map((item, itemIndex) => {
+    const origin: ReleaseChangeOrigin =
+      item.pr !== undefined
+        ? { kind: 'pull-request', number: item.pr }
+        : { kind: 'release-note', index: itemIndex };
+    return {
+      ...item,
+      id: buildReleaseChangeId(origin),
+      origin,
+    };
+  });
+}
 
 /**
  * Build release items from authoritative commit-to-PR associations.
@@ -14,18 +60,24 @@ import { stripConventionalPrefix } from '@/utils/title-normalize.js';
 export function buildReleaseItemsFromPullRequests(
   commits: readonly CommitLite[],
   pullRequestsBySha: Readonly<Record<string, readonly PullRef[]>>,
-): ReleaseItem[] {
+): ReleaseChange[] {
   if (commits.length === 0) return [];
 
-  const items: ReleaseItem[] = [];
-  const itemsByPrNumber = new Map<number, ReleaseItem>();
+  const items: ReleaseChange[] = [];
+  const itemsByPrNumber = new Map<number, ReleaseChange>();
   let foundPullRequest = false;
   for (const commit of commits) {
     const pullRequest = pullRequestsBySha[commit.sha]?.find((candidate) =>
       candidate.title?.trim(),
     );
     if (!pullRequest?.title) {
+      const origin: ReleaseChangeOrigin = {
+        kind: 'commit',
+        sha: commit.sha,
+      };
       items.push({
+        id: buildReleaseChangeId(origin),
+        origin,
         title: stripConventionalPrefix(commit.subject),
         rawTitle: commit.subject,
       });
@@ -35,7 +87,13 @@ export function buildReleaseItemsFromPullRequests(
     foundPullRequest = true;
     let item = itemsByPrNumber.get(pullRequest.number);
     if (!item) {
+      const origin: ReleaseChangeOrigin = {
+        kind: 'pull-request',
+        number: pullRequest.number,
+      };
       item = {
+        id: buildReleaseChangeId(origin),
+        origin,
         title: stripConventionalPrefix(pullRequest.title),
         rawTitle: pullRequest.title,
         author: pullRequest.author,

--- a/src/utils/release.ts
+++ b/src/utils/release.ts
@@ -1,5 +1,9 @@
 // WHY: Preserve the established import surface while keeping parsing,
 // commit mapping, and rendering in independently maintainable modules.
 export { buildReleaseItemsFromPullRequests } from '@/utils/release-items.js';
+export {
+  buildReleaseChangeId,
+  identifyReleaseItems,
+} from '@/utils/release-items.js';
 export { parseReleaseNotes } from '@/utils/release-notes.js';
 export { buildSectionFromRelease } from '@/utils/release-section.js';

--- a/tests/utils/release.test.ts
+++ b/tests/utils/release.test.ts
@@ -2,6 +2,7 @@
 import { test, expect, describe } from '@jest/globals';
 import {
   buildReleaseItemsFromPullRequests,
+  identifyReleaseItems,
   parseReleaseNotes,
   buildSectionFromRelease,
 } from '@/utils/release.js';
@@ -35,6 +36,8 @@ describe('release utils', () => {
 
     expect(items).toEqual([
       {
+        id: 'pr:138',
+        origin: { kind: 'pull-request', number: 138 },
         title: 'add opt-in WHY extraction',
         rawTitle: 'feat: add opt-in WHY extraction',
         author: 'nyaomaru',
@@ -57,14 +60,37 @@ describe('release utils', () => {
 
     expect(items).toEqual([
       {
+        id: 'pr:138',
+        origin: { kind: 'pull-request', number: 138 },
         title: 'add opt-in WHY extraction',
         rawTitle: 'feat: add opt-in WHY extraction',
         pr: 138,
       },
       {
+        id: 'commit:def',
+        origin: { kind: 'commit', sha: 'def' },
         title: 'recognize punctuated WHY headings',
         rawTitle: 'fix: recognize punctuated WHY headings',
       },
+    ]);
+  });
+
+  test('assigns distinct stable IDs to duplicate release-note titles', () => {
+    const changes = identifyReleaseItems([
+      { title: 'Improve output' },
+      { title: 'Improve output' },
+      { title: 'Fix rendering', pr: 42 },
+    ]);
+
+    expect(changes.map(({ id }) => id)).toEqual([
+      'release-note:0',
+      'release-note:1',
+      'pr:42',
+    ]);
+    expect(changes.map(({ origin }) => origin)).toEqual([
+      { kind: 'release-note', index: 0 },
+      { kind: 'release-note', index: 1 },
+      { kind: 'pull-request', number: 42 },
     ]);
   });
 


### PR DESCRIPTION
## Summary

Introduce canonical release change identity.

<!-- A brief summary of the changes -->

## Description

- document the planned v1 changelog content pipeline refactoring
- introduce canonical `ReleaseChange` values with stable IDs and source origins
- identify PR, commit, and release-note changes before classification

<!-- A detailed explanation of the changes, including why they are needed -->
