### PR TITLE
refactor: classify release changes by stable ID

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -1,6 +1,6 @@
 import type { LLMInput, LLMOutput } from '@/types/llm.js';
 import type { ProviderRuntimeConfig } from '@/types/config.js';
-import type { ClassifyTitlesOptions, Provider } from '@/types/provider.js';
+import type { ClassifyChangesOptions, Provider } from '@/types/provider.js';
 import type { WhyExtractionInput, WhyExtractionOutput } from '@/types/why.js';
 import { outputSchema } from '@/utils/output-json-schema.js';
 import { extractJsonObject } from '@/utils/json-extract.js';
@@ -16,10 +16,14 @@ import { PROVIDER_ANTHROPIC } from '@/constants/provider.js';
 import { RELEASE_NOTES_SYSTEM_PROMPT } from '@/constants/system-prompts.js';
 import {
   buildClassificationPrompt,
-  classifyTitlesWithFallback,
+  buildClassificationAssignmentsJsonSchema,
+  classifyChangesWithFallback,
 } from '@/providers/classification.js';
 import { isArray, isRecord, isString } from '@/utils/is.js';
-import type { CategoryMap } from '@/types/changelog.js';
+import type {
+  ClassificationChange,
+  ClassificationResult,
+} from '@/types/changelog.js';
 import {
   buildWhyExtractionPrompt,
   WHY_EXTRACTION_SYSTEM_PROMPT,
@@ -28,7 +32,7 @@ import {
 import { WhyExtractionOutputSchema } from '@/schema/why.js';
 
 const SYSTEM_ANTHROPIC_CLASSIFY =
-  'You are a changelog section classifier. Return JSON mapping each category to an array of titles. Use only the provided categories.';
+  'Classify each release change into one provided category. Return a JSON object mapping every change ID to its category. Do not rewrite IDs.';
 
 /**
  * Extract the assistant text content from an Anthropic Messages API response.
@@ -110,21 +114,17 @@ export class AnthropicProvider implements Provider {
     return extractJsonObject<LLMOutput>(outputText);
   }
 
-  async classifyTitles(
-    titles: string[],
-    options: ClassifyTitlesOptions = {},
-  ): Promise<CategoryMap> {
-    return classifyTitlesWithFallback({
-      titles,
+  async classifyChanges(
+    changes: ClassificationChange[],
+    options: ClassifyChangesOptions = {},
+  ): Promise<ClassificationResult> {
+    return classifyChangesWithFallback({
+      changes,
       hasApiKey: Boolean(this.apiKey),
       options,
       invalidResponseMessage: 'Anthropic classify output did not match schema',
       request: async () => {
-        const prompt = buildClassificationPrompt(titles);
-        const properties: Record<string, unknown> = {};
-        for (const category of prompt.categories) {
-          properties[category] = { type: 'array', items: { type: 'string' } };
-        }
+        const prompt = buildClassificationPrompt(changes);
 
         const payload = {
           model: this.modelName,
@@ -134,17 +134,13 @@ export class AnthropicProvider implements Provider {
           messages: [{ role: 'user', content: JSON.stringify(prompt) }],
           tools: [
             {
-              name: 'return_categories',
+              name: 'return_assignments',
               description:
-                'Return a JSON object mapping each category to an array of titles.',
-              input_schema: {
-                type: 'object',
-                properties,
-                additionalProperties: false,
-              },
+                'Return a JSON object mapping every change ID to one category.',
+              input_schema: buildClassificationAssignmentsJsonSchema(changes),
             },
           ],
-          tool_choice: { type: 'tool', name: 'return_categories' },
+          tool_choice: { type: 'tool', name: 'return_assignments' },
         } as const;
 
         const json = await postJson<unknown>(

--- a/src/providers/classification.ts
+++ b/src/providers/classification.ts
@@ -1,62 +1,105 @@
 import { SECTION_CHORE, SECTION_ORDER } from '@/constants/changelog.js';
-import type { CategoryMap } from '@/types/changelog.js';
-import type { ClassifyTitlesOptions } from '@/types/provider.js';
-import { arrayOf, isRecord, isString } from '@/utils/is.js';
-
-const isStringArray = arrayOf(isString);
+import type {
+  CategoryAssignments,
+  ClassificationChange,
+  ClassificationResult,
+} from '@/types/changelog.js';
+import type { ClassifyChangesOptions } from '@/types/provider.js';
+import { isBucketName, isRecord } from '@/utils/is.js';
 
 /** Prompt payload sent to classification LLMs. */
 export type ClassificationPrompt = {
-  /** Unique PR titles to categorize. */
-  titles: string[];
+  /** Canonical IDs and normalized titles to categorize. */
+  changes: ClassificationChange[];
   /** Ordered list of changelog categories to enforce. */
   categories: readonly string[];
 };
 
 /**
  * Build the shared classification prompt for provider-specific request code.
- * @param titles PR or release-note titles to classify.
- * @returns Prompt payload containing titles and canonical categories.
+ * @param changes Release changes to classify by stable ID.
+ * @returns Prompt payload containing changes and canonical categories.
  */
 export function buildClassificationPrompt(
-  titles: string[],
+  changes: ClassificationChange[],
 ): ClassificationPrompt {
-  return { titles, categories: SECTION_ORDER };
+  return { changes, categories: SECTION_ORDER };
 }
 
 /**
- * Return the deterministic category fallback used when classification is unavailable.
- * @param titles Titles that could not be classified by a provider.
- * @returns Category map with all titles grouped under Chore.
+ * Build a strict JSON schema for ID-to-category assignments.
+ * @param changes Release changes expected in the provider response.
+ * @returns JSON schema requiring one canonical category for every change ID.
  */
-export function fallbackCategoryMap(titles: string[]): CategoryMap {
-  return { [SECTION_CHORE]: titles };
+export function buildClassificationAssignmentsJsonSchema(
+  changes: ClassificationChange[],
+): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: Object.fromEntries(
+      changes.map(({ id }) => [
+        id,
+        { type: 'string', enum: [...SECTION_ORDER] },
+      ]),
+    ),
+    required: changes.map(({ id }) => id),
+    additionalProperties: false,
+  };
 }
 
 /**
- * Parse a JSON string into a CategoryMap when the shape matches expectations.
- * @param rawJson Serialized JSON string returned by the LLM.
- * @returns CategoryMap when valid, otherwise undefined.
+ * Return the deterministic fallback used when classification is unavailable.
+ * @param changes Changes that could not be classified by a provider.
+ * @returns Assignments placing every change under Chore.
  */
-export function parseCategoryMap(rawJson: string): CategoryMap | undefined {
+export function fallbackCategoryAssignments(
+  changes: ClassificationChange[],
+): CategoryAssignments {
+  return Object.fromEntries(
+    changes.map(({ id }) => [id, SECTION_CHORE]),
+  ) as CategoryAssignments;
+}
+
+/**
+ * Parse and reconcile a provider response against the requested change IDs.
+ * WHY: Provider output is untrusted and may omit entries or invent IDs. Missing
+ * IDs are recoverable, but unknown IDs and categories invalidate the response.
+ * @param rawJson Serialized ID-to-category object returned by the provider.
+ * @param changes Exact release changes included in the classification request.
+ * @returns Reconciled assignments, or undefined for an invalid response.
+ */
+export function parseCategoryAssignments(
+  rawJson: string,
+  changes: ClassificationChange[],
+): ClassificationResult | undefined {
   try {
     const parsed = JSON.parse(rawJson);
-    if (!isRecord(parsed)) {
-      return undefined;
-    }
+    if (!isRecord(parsed)) return undefined;
 
-    const result: CategoryMap = {};
-    for (const [category, titles] of Object.entries(parsed)) {
-      if (isStringArray(titles)) {
-        result[category] = [...titles];
+    const knownIds = new Set<string>(changes.map(({ id }) => id));
+    if (knownIds.size !== changes.length) return undefined;
+
+    const assignments = {} as CategoryAssignments;
+    for (const [changeId, category] of Object.entries(parsed)) {
+      if (!knownIds.has(changeId) || !isBucketName(category)) {
+        return undefined;
       }
+      assignments[changeId as keyof CategoryAssignments] = category;
     }
 
-    if (Object.keys(result).length === 0) {
-      return undefined;
+    const missingIds = changes
+      .map(({ id }) => id)
+      .filter((changeId) => assignments[changeId] === undefined);
+    for (const changeId of missingIds) {
+      assignments[changeId] = SECTION_CHORE;
     }
 
-    return result;
+    const diagnostics = missingIds.length
+      ? [
+          `Classification response omitted ${missingIds.length} change ID(s): ${missingIds.join(', ')}; used deterministic fallback`,
+        ]
+      : [];
+    return { assignments, diagnostics };
   } catch {
     return undefined;
   }
@@ -65,34 +108,42 @@ export function parseCategoryMap(rawJson: string): CategoryMap | undefined {
 /**
  * Run provider classification with the shared fallback and error policy.
  * @param params Classification inputs and provider-specific request callback.
- * @returns Parsed categories, an empty map for empty input, or the deterministic fallback.
+ * @returns Reconciled assignments and non-fatal diagnostics.
  */
-export async function classifyTitlesWithFallback(params: {
-  titles: string[];
+export async function classifyChangesWithFallback(params: {
+  changes: ClassificationChange[];
   hasApiKey: boolean;
-  options?: ClassifyTitlesOptions;
+  options?: ClassifyChangesOptions;
   request: () => Promise<string>;
   invalidResponseMessage: string;
-}): Promise<CategoryMap> {
+}): Promise<ClassificationResult> {
   const {
-    titles,
+    changes,
     hasApiKey,
     options = {},
     request,
     invalidResponseMessage,
   } = params;
 
-  if (!titles.length) return {};
-  if (!hasApiKey) return fallbackCategoryMap(titles);
+  if (!changes.length) return { assignments: {}, diagnostics: [] };
+  if (!hasApiKey) {
+    return {
+      assignments: fallbackCategoryAssignments(changes),
+      diagnostics: [],
+    };
+  }
 
   try {
-    const categories = parseCategoryMap(await request());
-    if (!categories) {
-      throw new Error(invalidResponseMessage);
-    }
-    return categories;
+    const result = parseCategoryAssignments(await request(), changes);
+    if (!result) throw new Error(invalidResponseMessage);
+    return result;
   } catch (error) {
     if (options.throwOnError) throw error;
-    return fallbackCategoryMap(titles);
+    return {
+      assignments: fallbackCategoryAssignments(changes),
+      diagnostics: [
+        `${invalidResponseMessage}; used deterministic fallback for all changes`,
+      ],
+    };
   }
 }

--- a/src/providers/classification.ts
+++ b/src/providers/classification.ts
@@ -7,6 +7,23 @@ import type {
 import type { ClassifyChangesOptions } from '@/types/provider.js';
 import { isBucketName, isRecord } from '@/utils/is.js';
 
+/** Strict-mode error carrying assignments recovered from an incomplete response. */
+export class IncompleteClassificationError extends Error {
+  /** Partially recovered result available to non-strict orchestration. */
+  readonly result: ClassificationResult;
+
+  /**
+   * Create an error for a provider response that omitted requested IDs.
+   * @param message Provider-specific schema failure message.
+   * @param result Reconciled assignments and omission diagnostics.
+   */
+  constructor(message: string, result: ClassificationResult) {
+    super(`${message}: ${result.diagnostics.join('; ')}`);
+    this.name = 'IncompleteClassificationError';
+    this.result = result;
+  }
+}
+
 /** Prompt payload sent to classification LLMs. */
 export type ClassificationPrompt = {
   /** Canonical IDs and normalized titles to categorize. */
@@ -136,6 +153,9 @@ export async function classifyChangesWithFallback(params: {
   try {
     const result = parseCategoryAssignments(await request(), changes);
     if (!result) throw new Error(invalidResponseMessage);
+    if (options.throwOnError && result.diagnostics.length) {
+      throw new IncompleteClassificationError(invalidResponseMessage, result);
+    }
     return result;
   } catch (error) {
     if (options.throwOnError) throw error;

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,7 +1,10 @@
 import type { LLMInput, LLMOutput } from '@/types/llm.js';
 import type { ProviderRuntimeConfig } from '@/types/config.js';
-import type { ClassifyTitlesOptions, Provider } from '@/types/provider.js';
-import type { CategoryMap } from '@/types/changelog.js';
+import type { ClassifyChangesOptions, Provider } from '@/types/provider.js';
+import type {
+  ClassificationChange,
+  ClassificationResult,
+} from '@/types/changelog.js';
 import type { WhyExtractionInput, WhyExtractionOutput } from '@/types/why.js';
 import { outputSchema } from '@/utils/output-json-schema.js';
 import { extractJsonObject } from '@/utils/json-extract.js';
@@ -17,7 +20,8 @@ import { PROVIDER_GEMINI } from '@/constants/provider.js';
 import { RELEASE_NOTES_SYSTEM_PROMPT } from '@/constants/system-prompts.js';
 import {
   buildClassificationPrompt,
-  classifyTitlesWithFallback,
+  buildClassificationAssignmentsJsonSchema,
+  classifyChangesWithFallback,
 } from '@/providers/classification.js';
 import {
   buildWhyExtractionPrompt,
@@ -27,7 +31,7 @@ import {
 } from '@/providers/why.js';
 
 const SYSTEM_GEMINI_CLASSIFY =
-  'Classify each pull request title into one of the given categories. Return a JSON object with those categories as keys and arrays of titles as values.';
+  'Classify each release change into one provided category. Return a JSON object mapping every change ID to its category. Do not rewrite IDs.';
 
 /** Subset of the Gemini generateContent response payload we rely on. */
 type GeminiResponse = {
@@ -122,21 +126,17 @@ export class GeminiProvider implements Provider {
     return extractJsonObject<LLMOutput>(extractGeminiText(response));
   }
 
-  async classifyTitles(
-    titles: string[],
-    options: ClassifyTitlesOptions = {},
-  ): Promise<CategoryMap> {
-    return classifyTitlesWithFallback({
-      titles,
+  async classifyChanges(
+    changes: ClassificationChange[],
+    options: ClassifyChangesOptions = {},
+  ): Promise<ClassificationResult> {
+    return classifyChangesWithFallback({
+      changes,
       hasApiKey: Boolean(this.apiKey),
       options,
       invalidResponseMessage: 'Gemini classify output did not match schema',
       request: async () => {
-        const prompt = buildClassificationPrompt(titles);
-        const properties: Record<string, unknown> = {};
-        for (const category of prompt.categories) {
-          properties[category] = { type: 'array', items: { type: 'string' } };
-        }
+        const prompt = buildClassificationPrompt(changes);
 
         const payload = {
           systemInstruction: {
@@ -152,12 +152,8 @@ export class GeminiProvider implements Provider {
             maxOutputTokens: LLM_CLASSIFY_MAX_TOKENS,
             temperature: 0,
             responseMimeType: 'application/json',
-            responseJsonSchema: {
-              type: 'object',
-              properties,
-              required: [...prompt.categories],
-              additionalProperties: false,
-            },
+            responseJsonSchema:
+              buildClassificationAssignmentsJsonSchema(changes),
           },
         } as const;
 

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,6 +1,6 @@
 import type { LLMInput, LLMOutput } from '@/types/llm.js';
 import type { ProviderRuntimeConfig } from '@/types/config.js';
-import type { ClassifyTitlesOptions, Provider } from '@/types/provider.js';
+import type { ClassifyChangesOptions, Provider } from '@/types/provider.js';
 import type { WhyExtractionInput, WhyExtractionOutput } from '@/types/why.js';
 import { outputSchema } from '@/utils/output-json-schema.js';
 import { extractJsonObject } from '@/utils/json-extract.js';
@@ -18,9 +18,12 @@ import { PROVIDER_OPENAI } from '@/constants/provider.js';
 import { RELEASE_NOTES_SYSTEM_PROMPT } from '@/constants/system-prompts.js';
 import {
   buildClassificationPrompt,
-  classifyTitlesWithFallback,
+  classifyChangesWithFallback,
 } from '@/providers/classification.js';
-import type { CategoryMap } from '@/types/changelog.js';
+import type {
+  ClassificationChange,
+  ClassificationResult,
+} from '@/types/changelog.js';
 import {
   buildWhyExtractionPrompt,
   parseWhyExtractionOutput,
@@ -42,7 +45,7 @@ type OpenAIResponse = {
 };
 
 const SYSTEM_OPENAI_CLASSIFY =
-  'Classify each pull request title into one of the given categories. Return a JSON object with those categories as keys and arrays of titles as values.';
+  'Classify each release change into one provided category. Return a JSON object mapping every change ID to its category. Do not rewrite IDs.';
 
 /**
  * Extract the assistant message content from an OpenAI Chat Completions response.
@@ -139,17 +142,17 @@ export class OpenAIProvider implements Provider {
     return extractJsonObject<LLMOutput>(extractOpenAiResponseText(resp));
   }
 
-  async classifyTitles(
-    titles: string[],
-    options: ClassifyTitlesOptions = {},
-  ): Promise<CategoryMap> {
-    return classifyTitlesWithFallback({
-      titles,
+  async classifyChanges(
+    changes: ClassificationChange[],
+    options: ClassifyChangesOptions = {},
+  ): Promise<ClassificationResult> {
+    return classifyChangesWithFallback({
+      changes,
       hasApiKey: Boolean(this.apiKey),
       options,
       invalidResponseMessage: 'OpenAI classify output did not match schema',
       request: async () => {
-        const prompt = buildClassificationPrompt(titles);
+        const prompt = buildClassificationPrompt(changes);
         let text: string;
         if (isReasoningModel(this.modelName)) {
           const payload = buildOpenAiResponsePayload(

--- a/src/types/changelog.ts
+++ b/src/types/changelog.ts
@@ -1,7 +1,5 @@
 import { SECTION_ORDER } from '@/constants/changelog.js';
-
-/** Maps changelog section names to the titles that belong in each. */
-export type CategoryMap = Record<string, string[]>;
+import type { ReleaseChangeId } from '@/types/release.js';
 
 /** Numeric score per section name used for heuristic category scoring. */
 export type CategoryScores = Record<string, number>;
@@ -11,3 +9,22 @@ export type CategoryScores = Record<string, number>;
  * Keeps section identifiers consistent across the codebase.
  */
 export type BucketName = (typeof SECTION_ORDER)[number];
+
+/** Stable identity and editable text sent to a classification provider. */
+export type ClassificationChange = {
+  /** Canonical release-change identifier. */
+  id: ReleaseChangeId;
+  /** Normalized title used only as classification context. */
+  title: string;
+};
+
+/** Maps each release-change ID to exactly one changelog category. */
+export type CategoryAssignments = Record<ReleaseChangeId, BucketName>;
+
+/** Reconciled classification output and any deterministic fallback notices. */
+export type ClassificationResult = {
+  /** Validated category assignments keyed by release-change ID. */
+  assignments: CategoryAssignments;
+  /** Non-fatal reconciliation notices suitable for dry-run diagnostics. */
+  diagnostics: string[];
+};

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -1,5 +1,8 @@
 import type { LLMInput, LLMOutput, ProviderName } from '@/types/llm.js';
-import type { CategoryMap } from '@/types/changelog.js';
+import type {
+  ClassificationChange,
+  ClassificationResult,
+} from '@/types/changelog.js';
 import type { WhyExtractionInput, WhyExtractionOutput } from '@/types/why.js';
 
 /** Capability flags for a provider implementation. */
@@ -24,8 +27,8 @@ export type ProviderInfo = {
   supports: ProviderCapabilities;
 };
 
-/** Options controlling provider title classification error handling. */
-export type ClassifyTitlesOptions = {
+/** Options controlling provider change-classification error handling. */
+export type ClassifyChangesOptions = {
   /** Throw provider/parse errors instead of returning deterministic fallback categories. */
   throwOnError?: boolean;
 };
@@ -37,11 +40,11 @@ export type ClassifyTitlesOptions = {
 export interface Provider extends ProviderInfo {
   /** Generate structured output from normalized input. */
   generate(input: LLMInput): Promise<LLMOutput>;
-  /** Classify titles into changelog categories. */
-  classifyTitles(
-    titles: string[],
-    options?: ClassifyTitlesOptions,
-  ): Promise<CategoryMap>;
+  /** Classify canonical release changes into changelog categories. */
+  classifyChanges(
+    changes: ClassificationChange[],
+    options?: ClassifyChangesOptions,
+  ): Promise<ClassificationResult>;
   /** Extract concise WHY notes from preprocessed PR description candidates. */
   extractWhyNotes(input: WhyExtractionInput): Promise<WhyExtractionOutput>;
 }

--- a/src/utils/category-tune.ts
+++ b/src/utils/category-tune.ts
@@ -6,8 +6,9 @@ import {
 } from '@/constants/conventional.js';
 import type {
   BucketName,
-  CategoryMap,
+  CategoryAssignments,
   CategoryScores,
+  ClassificationChange,
 } from '@/types/changelog.js';
 import {
   SECTION_ADDED,
@@ -18,14 +19,13 @@ import {
   SECTION_DOCS,
   SECTION_TEST,
 } from '@/constants/changelog.js';
-import type { ReleaseItem } from '@/types/release.js';
+import type { ReleaseChange, ReleaseChangeId } from '@/types/release.js';
 import {
   bestCategory,
   scoreCategories,
   SCORE_THRESHOLDS,
 } from '@/utils/category-score.js';
 import { isDependencyUpdateTitle } from '@/utils/dependency-update.js';
-import { isArray, isBucketName } from '@/utils/is.js';
 
 const TYPE_INTENT_INDICATORS = [
   'type',
@@ -80,12 +80,6 @@ const CHANGE_LIKE_INDICATORS = [
   'finetune',
 ];
 
-const REQUIRED_CATEGORY_BUCKETS = [
-  SECTION_FIXED,
-  SECTION_CHANGED,
-  SECTION_ADDED,
-] as const;
-
 const WEAK_REMAP_BUCKETS = new Set<BucketName>([
   SECTION_CHORE,
   SECTION_DOCS,
@@ -96,81 +90,17 @@ function semanticTitleCore(rawTitle: string): string {
   return rawTitle.toLowerCase().replace(CONVENTIONAL_PREFIX_RE, '').trim();
 }
 
-function collectKnownTitles(
-  items: ReleaseItem[],
-  categories: CategoryMap,
+function releaseChangeTitles(
+  change: ReleaseChange,
+  classificationTitle?: string,
 ): string[] {
-  const knownTitles = new Set<string>();
-
-  for (const item of items) {
-    if (item.rawTitle) knownTitles.add(item.rawTitle);
-    knownTitles.add(item.title);
-  }
-
-  for (const list of Object.values(categories)) {
-    if (!isArray(list)) continue;
-    for (const title of list) {
-      knownTitles.add(title);
-    }
-  }
-
-  return Array.from(knownTitles);
-}
-
-function cloneCategoryMap(categories: CategoryMap): CategoryMap {
-  const adjusted: CategoryMap = Object.fromEntries(
-    Object.entries(categories).map(([section, list]) => [
-      section,
-      isArray(list) ? list.slice() : [],
-    ]),
+  return Array.from(
+    new Set(
+      [change.rawTitle, change.title, classificationTitle].filter(
+        (title): title is string => Boolean(title),
+      ),
+    ),
   );
-
-  for (const section of REQUIRED_CATEGORY_BUCKETS) {
-    if (!adjusted[section]) adjusted[section] = [];
-  }
-
-  return adjusted;
-}
-
-/**
- * Move given titles to a target category on a mutable CategoryMap.
- * - Removes titles from all buckets first to avoid duplicates.
- * - Ensures the target bucket exists and appends uniquely.
- */
-function moveTitlesToCategory(
-  adjusted: CategoryMap,
-  titles: string[],
-  targetCategory: BucketName,
-): void {
-  if (!isArray(adjusted[targetCategory])) adjusted[targetCategory] = [];
-  const target = adjusted[targetCategory];
-  for (const title of titles) {
-    for (const list of Object.values(adjusted)) {
-      if (!isArray(list)) continue;
-      const titleIndex = list.indexOf(title);
-      if (titleIndex !== -1) list.splice(titleIndex, 1);
-    }
-    if (!target.includes(title)) target.push(title);
-  }
-}
-
-function collectMatchingTitles(
-  titles: string[],
-  predicate: (title: string) => boolean,
-): string[] {
-  return titles.filter((title) => predicate(title));
-}
-
-function findCategory(
-  categories: CategoryMap,
-  title: string,
-): BucketName | undefined {
-  for (const [section, list] of Object.entries(categories)) {
-    if (isArray(list) && list.includes(title) && isBucketName(section)) {
-      return section;
-    }
-  }
-  return undefined;
 }
 
 function shouldMoveChangeLikeTitle(
@@ -228,18 +158,20 @@ function confidentScoredCategory(scores: CategoryScores): BucketName | null {
   return null;
 }
 
-function applyScoredWeakBucketRemaps(
-  adjusted: CategoryMap,
+function applyScoredWeakBucketRemap(
+  adjusted: CategoryAssignments,
+  changeId: ReleaseChangeId,
   titles: string[],
 ): void {
   for (const title of titles) {
-    const currentCategory = findCategory(adjusted, title);
+    const currentCategory = adjusted[changeId];
     if (!currentCategory || !WEAK_REMAP_BUCKETS.has(currentCategory)) continue;
 
     const targetCategory = confidentScoredCategory(scoreCategories(title));
     if (!targetCategory) continue;
 
-    moveTitlesToCategory(adjusted, [title], targetCategory);
+    adjusted[changeId] = targetCategory;
+    return;
   }
 }
 
@@ -290,63 +222,62 @@ export function isChangeLikeTitle(rawTitle: string): boolean {
 }
 
 /**
- * Re-map category assignments so that titles implying a fix (e.g., type tightening) land in `Fixed`.
- * @param items Parsed release items (with rawTitle/title values).
- * @param categories Category mapping produced by the classifier.
- * @returns Adjusted CategoryMap with qualifying titles moved to `Fixed`.
+ * Re-map ID-based assignments using deterministic title signals.
+ * @param changes Canonical changes containing raw and display titles.
+ * @param assignments Category assignments produced by the classifier.
+ * @param classificationChanges Normalized titles sent to the classifier.
+ * @returns Adjusted assignments keyed by the same stable change IDs.
  */
-export function tuneCategoriesByTitle(
-  items: ReleaseItem[],
-  categories: CategoryMap,
-): CategoryMap {
-  if (!items.length) return categories;
+export function tuneCategoryAssignmentsByTitle(
+  changes: ReleaseChange[],
+  assignments: CategoryAssignments,
+  classificationChanges: ClassificationChange[] = [],
+): CategoryAssignments {
+  if (!changes.length) return assignments;
 
-  const adjusted = cloneCategoryMap(categories);
-  const allKnownTitles = collectKnownTitles(items, categories);
-
-  // Rule: Dependency-only updates should remain in Chore to avoid noise in Changed.
-  const dependencyUpdates = collectMatchingTitles(
-    allKnownTitles,
-    isDependencyUpdateTitle,
+  const adjusted = { ...assignments };
+  const classificationTitles = new Map(
+    classificationChanges.map(({ id, title }) => [id, title]),
   );
-  if (dependencyUpdates.length)
-    moveTitlesToCategory(adjusted, dependencyUpdates, SECTION_CHORE);
-  const dependencyUpdateSet = new Set(dependencyUpdates);
-  const nonDependencyTitles = allKnownTitles.filter(
-    (title) => !dependencyUpdateSet.has(title),
-  );
+  for (const change of changes) {
+    const titles = releaseChangeTitles(
+      change,
+      classificationTitles.get(change.id),
+    );
+    adjusted[change.id] ??= SECTION_CHORE;
 
-  const implicitFixes = collectMatchingTitles(
-    nonDependencyTitles,
-    isImplicitFixTitle,
-  );
-  if (implicitFixes.length)
-    moveTitlesToCategory(adjusted, implicitFixes, SECTION_FIXED);
+    // Dependency-only updates should remain in Chore to avoid Changed noise.
+    if (titles.some(isDependencyUpdateTitle)) {
+      adjusted[change.id] = SECTION_CHORE;
+      continue;
+    }
 
-  // Rule: Conventional `fix:` prefix should map to Fixed.
-  const conventionalFixes = collectMatchingTitles(
-    nonDependencyTitles,
-    (title) => FIX_PREFIX_FLEX_RE.test(title),
-  );
-  if (conventionalFixes.length)
-    moveTitlesToCategory(adjusted, conventionalFixes, SECTION_FIXED);
+    if (titles.some(isImplicitFixTitle)) {
+      adjusted[change.id] = SECTION_FIXED;
+    }
 
-  // Secondary rule: refactor/perf/style-like items should land in Changed when misclassified as Chore or missing.
-  const changeLikeTitles = nonDependencyTitles.filter((title) =>
-    shouldMoveChangeLikeTitle(title, findCategory(adjusted, title)),
-  );
-  if (changeLikeTitles.length)
-    moveTitlesToCategory(adjusted, changeLikeTitles, SECTION_CHANGED);
+    // Conventional `fix:` prefixes should map to Fixed.
+    if (titles.some((title) => FIX_PREFIX_FLEX_RE.test(title))) {
+      adjusted[change.id] = SECTION_FIXED;
+    }
 
-  // Rule: Conventional `feat:` prefix should map to Added (guard against LLM
-  // placing features under Chore/Changed due to generic verbs like "add/support").
-  const featureTitles = collectMatchingTitles(nonDependencyTitles, (title) =>
-    FEAT_PREFIX_FLEX_RE.test(title),
-  );
-  if (featureTitles.length)
-    moveTitlesToCategory(adjusted, featureTitles, SECTION_ADDED);
+    // Refactor/perf/style-like items should land in Changed when the current
+    // assignment is weak or incorrectly marked as Added.
+    if (
+      titles.some((title) =>
+        shouldMoveChangeLikeTitle(title, adjusted[change.id]),
+      )
+    ) {
+      adjusted[change.id] = SECTION_CHANGED;
+    }
 
-  applyScoredWeakBucketRemaps(adjusted, nonDependencyTitles);
+    // Conventional `feat:` prefixes override weak provider classifications.
+    if (titles.some((title) => FEAT_PREFIX_FLEX_RE.test(title))) {
+      adjusted[change.id] = SECTION_ADDED;
+    }
+
+    applyScoredWeakBucketRemap(adjusted, change.id, titles);
+  }
 
   return adjusted;
 }

--- a/src/utils/classify-pre.ts
+++ b/src/utils/classify-pre.ts
@@ -5,7 +5,8 @@ import {
   REFACTOR_PERF_STYLE_PREFIX_FLEX_RE,
   FEAT_PREFIX_FLEX_RE,
 } from '@/constants/conventional.js';
-import type { ReleaseItem } from '@/types/release.js';
+import type { ClassificationChange } from '@/types/changelog.js';
+import type { ReleaseChange } from '@/types/release.js';
 import {
   isImplicitFixTitle,
   isChangeLikeTitle,
@@ -18,72 +19,58 @@ import {
 } from '@/constants/changelog.js';
 
 /**
- * Normalize titles to make LLM classification more deterministic without
- * affecting the final rendered titles. We only change the conventional
- * prefix for the classifier input; later lookup strips it.
+ * Normalize change titles for classification without changing their IDs or
+ * final rendered titles.
  *
  * Rules:
  * - Implicit type corrections → prefix with `fix:`
  * - Refactor/perf/style-like → ensure `refactor:` prefix
  * - Otherwise, keep the original raw title when available
+ * @param items Canonical release changes to prepare for classification.
+ * @returns Stable IDs paired with normalized classification titles.
  */
-export function buildTitlesForClassification(items: ReleaseItem[]): string[] {
-  const out: string[] = [];
+export function buildChangesForClassification(
+  items: ReleaseChange[],
+): ClassificationChange[] {
+  const changes: ClassificationChange[] = [];
   // Use flexible conventional-prefix regexes to support scope and breaking markers.
   for (const item of items) {
     const base = (item.rawTitle ?? item.title ?? '').trim();
-    if (!base) continue;
-
     const lower = base.toLowerCase();
     const core = base.replace(CONVENTIONAL_PREFIX_RE, '').trim();
+    let title = base;
 
     // If the title implies a correctness fix (e.g., typing/contract fix),
     // present it as a conventional `fix:` for the classifier.
     if (isImplicitFixTitle(base) && !FIX_PREFIX_FLEX_RE.test(lower)) {
-      out.push(`fix: ${core}`);
-      continue;
+      title = `fix: ${core}`;
+    } else if (REFACTOR_LIKE_RE.test(lower)) {
+      // Normalize refactor/perf/style to refactor: for consistent Changed mapping.
+      title = REFACTOR_PERF_STYLE_PREFIX_FLEX_RE.test(lower)
+        ? base
+        : `refactor: ${core}`;
+    } else if (isChangeLikeTitle(base)) {
+      // Nudge change-like improvements toward Changed by presenting as refactor.
+      title = REFACTOR_PERF_STYLE_PREFIX_FLEX_RE.test(lower)
+        ? base
+        : `refactor: ${core}`;
+    } else {
+      // Scoring-guided normalization when no earlier rule matched.
+      const scores = scoreCategories(base);
+      const guide = bestCategory(scores);
+      if (guide === SECTION_FIXED && !FIX_PREFIX_FLEX_RE.test(lower)) {
+        title = `fix: ${core}`;
+      } else if (
+        guide === SECTION_CHANGED &&
+        !REFACTOR_PERF_STYLE_PREFIX_FLEX_RE.test(lower)
+      ) {
+        title = `refactor: ${core}`;
+      } else if (guide === SECTION_ADDED && !FEAT_PREFIX_FLEX_RE.test(lower)) {
+        title = `feat: ${core}`;
+      }
     }
 
-    // Normalize refactor/perf/style to refactor: for consistent Changed mapping.
-    if (REFACTOR_LIKE_RE.test(lower)) {
-      out.push(
-        REFACTOR_PERF_STYLE_PREFIX_FLEX_RE.test(lower)
-          ? base
-          : `refactor: ${core}`,
-      );
-      continue;
-    }
-
-    // Nudge change-like improvements toward Changed by presenting as refactor.
-    if (isChangeLikeTitle(base)) {
-      out.push(
-        REFACTOR_PERF_STYLE_PREFIX_FLEX_RE.test(lower)
-          ? base
-          : `refactor: ${core}`,
-      );
-      continue;
-    }
-
-    // Scoring-guided normalization when no earlier rule matched
-    const scores = scoreCategories(base);
-    const guide = bestCategory(scores);
-    if (guide === SECTION_FIXED && !FIX_PREFIX_FLEX_RE.test(lower)) {
-      out.push(`fix: ${core}`);
-      continue;
-    }
-    if (
-      guide === SECTION_CHANGED &&
-      !REFACTOR_PERF_STYLE_PREFIX_FLEX_RE.test(lower)
-    ) {
-      out.push(`refactor: ${core}`);
-      continue;
-    }
-    if (guide === SECTION_ADDED && !FEAT_PREFIX_FLEX_RE.test(lower)) {
-      out.push(`feat: ${core}`);
-      continue;
-    }
-
-    out.push(base);
+    changes.push({ id: item.id, title });
   }
-  return out;
+  return changes;
 }

--- a/src/utils/classify.ts
+++ b/src/utils/classify.ts
@@ -3,9 +3,12 @@ import type {
   ProviderRuntimeConfig,
   ProviderRuntimeConfigMap,
 } from '@/types/config.js';
-import type { CategoryMap } from '@/types/changelog.js';
+import type {
+  ClassificationChange,
+  ClassificationResult,
+} from '@/types/changelog.js';
 import type { Provider } from '@/types/provider.js';
-import { fallbackCategoryMap } from '@/providers/classification.js';
+import { fallbackCategoryAssignments } from '@/providers/classification.js';
 import { providerFactory } from '@/utils/provider.js';
 import { isString } from '@/utils/is.js';
 
@@ -22,27 +25,30 @@ function providerFromConfig(
 }
 
 /**
- * Classify PR titles into changelog categories using the selected LLM provider.
+ * Classify canonical changes using the selected LLM provider.
  * Falls back to classifying all as `Chore` when no API key is present or on failure.
  * WHY: Provider-specific request details live in provider adapters; this helper
- * remains as a stable compatibility wrapper for existing callers.
- * @param titles List of PR titles to classify.
+ * centralizes provider selection for callers that only have a provider name.
+ * @param changes Stable IDs and normalized titles to classify.
  * @param provider Provider adapter or provider name.
  * @param config Runtime config required when passing a provider name.
- * @returns Map of category -> titles.
+ * @returns Reconciled ID-to-category assignments and diagnostics.
  */
-export async function classifyTitles(
-  titles: string[],
+export async function classifyChanges(
+  changes: ClassificationChange[],
   provider: Provider | ProviderName,
   config?: ProviderRuntimeConfig,
-): Promise<CategoryMap> {
-  if (!titles.length) return {};
+): Promise<ClassificationResult> {
+  if (!changes.length) return { assignments: {}, diagnostics: [] };
   if (!isString(provider)) {
-    return provider.classifyTitles(titles);
+    return provider.classifyChanges(changes);
   }
   if (!config) {
-    return fallbackCategoryMap(titles);
+    return {
+      assignments: fallbackCategoryAssignments(changes),
+      diagnostics: [],
+    };
   }
   const providerAdapter = providerFromConfig(provider, config);
-  return providerAdapter.classifyTitles(titles);
+  return providerAdapter.classifyChanges(changes);
 }

--- a/src/utils/llm-output-release-notes.ts
+++ b/src/utils/llm-output-release-notes.ts
@@ -5,9 +5,9 @@ import {
   parseReleaseNotes,
   buildSectionFromRelease,
 } from '@/utils/release.js';
-import { tuneCategoriesByTitle } from '@/utils/category-tune.js';
-import { buildTitlesForClassification } from '@/utils/classify-pre.js';
-import { fallbackCategoryMap } from '@/providers/classification.js';
+import { tuneCategoryAssignmentsByTitle } from '@/utils/category-tune.js';
+import { buildChangesForClassification } from '@/utils/classify-pre.js';
+import { fallbackCategoryAssignments } from '@/providers/classification.js';
 import { LlmError } from '@/lib/errors.js';
 import {
   DEFAULT_PR_LABELS,
@@ -27,6 +27,7 @@ import {
 } from '@/utils/llm-output-common.js';
 import { isError } from '@/utils/is.js';
 import type { ReleaseChange } from '@/types/release.js';
+import type { CategoryAssignments } from '@/types/changelog.js';
 
 /**
  * Fill missing PR numbers/URLs/authors for release note items when possible.
@@ -123,16 +124,22 @@ export async function buildOutputFromReleaseNotes(
     items: releaseChanges,
   });
 
-  const titlesForLLM = buildTitlesForClassification(releaseChanges);
-  let categories: Record<string, string[]> = {};
-  if (titlesForLLM.length) {
+  const changesForClassification =
+    buildChangesForClassification(releaseChanges);
+  let assignments = {} as CategoryAssignments;
+  if (changesForClassification.length) {
     if (noAi) {
-      categories = fallbackCategoryMap(titlesForLLM);
+      assignments = fallbackCategoryAssignments(changesForClassification);
     } else {
       try {
-        categories = await provider.classifyTitles(titlesForLLM, {
-          throwOnError: true,
-        });
+        const classification = await provider.classifyChanges(
+          changesForClassification,
+          {
+            throwOnError: true,
+          },
+        );
+        assignments = classification.assignments;
+        fallbackReasons.push(...classification.diagnostics);
         // Mark AI usage only when classification had input and a provider key is available.
         aiUsed = aiUsed || hasProviderKey;
       } catch (err) {
@@ -141,18 +148,22 @@ export async function buildOutputFromReleaseNotes(
           throw new LlmError(`LLM classification failed: ${message}`);
         }
         fallbackReasons.push(`LLM classification failed: ${message}`);
-        categories = fallbackCategoryMap(titlesForLLM);
+        assignments = fallbackCategoryAssignments(changesForClassification);
       }
     }
     // Heuristic tuning: ensure typing/contract corrections are grouped under Fixed.
-    categories = tuneCategoriesByTitle(releaseChanges, categories);
+    assignments = tuneCategoryAssignmentsByTitle(
+      releaseChanges,
+      assignments,
+      changesForClassification,
+    );
   }
 
   const section = buildSectionFromRelease({
     version,
     date,
-    items: releaseChanges,
-    categories,
+    changes: releaseChanges,
+    assignments,
     fullChangelog: parsedRelease.fullChangelog,
     sections: parsedRelease.sections,
   });

--- a/src/utils/llm-output-release-notes.ts
+++ b/src/utils/llm-output-release-notes.ts
@@ -8,7 +8,10 @@ import {
 } from '@/utils/release.js';
 import { tuneCategoryAssignmentsByTitle } from '@/utils/category-tune.js';
 import { buildChangesForClassification } from '@/utils/classify-pre.js';
-import { fallbackCategoryAssignments } from '@/providers/classification.js';
+import {
+  fallbackCategoryAssignments,
+  IncompleteClassificationError,
+} from '@/providers/classification.js';
 import { LlmError } from '@/lib/errors.js';
 import {
   DEFAULT_PR_LABELS,
@@ -145,12 +148,18 @@ export async function buildOutputFromReleaseNotes(
         // Mark AI usage only when classification had input and a provider key is available.
         aiUsed = aiUsed || hasProviderKey;
       } catch (err) {
-        const message = isError(err) ? err.message : String(err);
-        if (failOnLlmError) {
-          throw new LlmError(`LLM classification failed: ${message}`);
+        if (err instanceof IncompleteClassificationError && !failOnLlmError) {
+          assignments = err.result.assignments;
+          fallbackReasons.push(...err.result.diagnostics);
+          aiUsed = aiUsed || hasProviderKey;
+        } else {
+          const message = isError(err) ? err.message : String(err);
+          if (failOnLlmError) {
+            throw new LlmError(`LLM classification failed: ${message}`);
+          }
+          fallbackReasons.push(`LLM classification failed: ${message}`);
+          assignments = fallbackCategoryAssignments(changesForClassification);
         }
-        fallbackReasons.push(`LLM classification failed: ${message}`);
-        assignments = fallbackCategoryAssignments(changesForClassification);
       }
     }
     // Heuristic tuning: ensure typing/contract corrections are grouped under Fixed.

--- a/src/utils/llm-output-release-notes.ts
+++ b/src/utils/llm-output-release-notes.ts
@@ -1,6 +1,7 @@
 import { fetchPRInfo } from '@/lib/github.js';
 import {
   buildReleaseItemsFromPullRequests,
+  deduplicateReleaseChangesByPullRequest,
   identifyReleaseItems,
   parseReleaseNotes,
   buildSectionFromRelease,
@@ -123,6 +124,7 @@ export async function buildOutputFromReleaseNotes(
     titleToPr,
     items: releaseChanges,
   });
+  releaseChanges = deduplicateReleaseChangesByPullRequest(releaseChanges);
 
   const changesForClassification =
     buildChangesForClassification(releaseChanges);

--- a/src/utils/release-items.ts
+++ b/src/utils/release-items.ts
@@ -42,17 +42,38 @@ export function buildReleaseChangeId(
 export function identifyReleaseItems(
   items: readonly ReleaseItem[],
 ): ReleaseChange[] {
-  return items.map((item, itemIndex) => {
+  const changes: ReleaseChange[] = [];
+  const changesByPrNumber = new Map<number, ReleaseChange>();
+
+  items.forEach((item, itemIndex) => {
     const origin: ReleaseChangeOrigin =
       item.pr !== undefined
         ? { kind: 'pull-request', number: item.pr }
         : { kind: 'release-note', index: itemIndex };
-    return {
+    const existingPrChange =
+      origin.kind === 'pull-request'
+        ? changesByPrNumber.get(origin.number)
+        : undefined;
+    if (existingPrChange) {
+      // WHY: A generated release body may mention one PR more than once. Keep
+      // the first display entry while retaining metadata found on later rows.
+      existingPrChange.author ??= item.author;
+      existingPrChange.url ??= item.url;
+      return;
+    }
+
+    const change: ReleaseChange = {
       ...item,
       id: buildReleaseChangeId(origin),
       origin,
     };
+    changes.push(change);
+    if (origin.kind === 'pull-request') {
+      changesByPrNumber.set(origin.number, change);
+    }
   });
+
+  return changes;
 }
 
 /**

--- a/src/utils/release-items.ts
+++ b/src/utils/release-items.ts
@@ -42,38 +42,53 @@ export function buildReleaseChangeId(
 export function identifyReleaseItems(
   items: readonly ReleaseItem[],
 ): ReleaseChange[] {
-  const changes: ReleaseChange[] = [];
-  const changesByPrNumber = new Map<number, ReleaseChange>();
-
-  items.forEach((item, itemIndex) => {
+  const changes = items.map((item, itemIndex) => {
     const origin: ReleaseChangeOrigin =
       item.pr !== undefined
         ? { kind: 'pull-request', number: item.pr }
         : { kind: 'release-note', index: itemIndex };
-    const existingPrChange =
-      origin.kind === 'pull-request'
-        ? changesByPrNumber.get(origin.number)
-        : undefined;
-    if (existingPrChange) {
-      // WHY: A generated release body may mention one PR more than once. Keep
-      // the first display entry while retaining metadata found on later rows.
-      existingPrChange.author ??= item.author;
-      existingPrChange.url ??= item.url;
-      return;
-    }
-
-    const change: ReleaseChange = {
+    return {
       ...item,
       id: buildReleaseChangeId(origin),
       origin,
     };
-    changes.push(change);
-    if (origin.kind === 'pull-request') {
-      changesByPrNumber.set(origin.number, change);
-    }
   });
 
-  return changes;
+  return deduplicateReleaseChangesByPullRequest(changes);
+}
+
+/**
+ * Deduplicate canonical changes by their final enriched pull request number.
+ * WHY: Title-based enrichment runs after initial identification and can reveal
+ * that separately parsed release-note rows refer to the same pull request.
+ * @param changes Canonical changes after any available PR enrichment.
+ * @returns Source-ordered changes containing at most one entry per PR number.
+ */
+export function deduplicateReleaseChangesByPullRequest(
+  changes: readonly ReleaseChange[],
+): ReleaseChange[] {
+  const deduplicatedChanges: ReleaseChange[] = [];
+  const changesByPrNumber = new Map<number, ReleaseChange>();
+
+  for (const change of changes) {
+    if (change.pr === undefined) {
+      deduplicatedChanges.push(change);
+      continue;
+    }
+
+    const existingChange = changesByPrNumber.get(change.pr);
+    if (existingChange) {
+      // Keep the first display entry while retaining metadata found later.
+      existingChange.author ??= change.author;
+      existingChange.url ??= change.url;
+      continue;
+    }
+
+    changesByPrNumber.set(change.pr, change);
+    deduplicatedChanges.push(change);
+  }
+
+  return deduplicatedChanges;
 }
 
 /**

--- a/src/utils/release-section.ts
+++ b/src/utils/release-section.ts
@@ -1,81 +1,26 @@
 import { SECTION_ORDER } from '@/constants/changelog.js';
-import type { ReleaseItem, ReleaseSection } from '@/types/release.js';
+import type { CategoryAssignments } from '@/types/changelog.js';
+import type { ReleaseChange, ReleaseSection } from '@/types/release.js';
 import {
   CHANGELOG_ADDITIONAL_SECTION_HEADING_LEVEL,
   demoteAdditionalSectionHeadings,
 } from '@/utils/release-markdown.js';
-import {
-  buildTitleLookup,
-  findTitleMatch,
-  type TitleLookup,
-} from '@/utils/title-lookup.js';
 
-const RELEASE_TITLE_MATCH_MIN_RELATIVE_PREFIX_LENGTH = 0.5;
-
-function buildReleaseItemLookup(
-  items: ReleaseItem[],
-): TitleLookup<ReleaseItem> {
-  return buildTitleLookup(
-    items.map((item) => ({
-      // WHY: LLM output can refer to either the stripped or raw title.
-      titles: new Set(
-        [item.title, item.rawTitle].filter((title): title is string =>
-          Boolean(title),
-        ),
-      ),
-      value: item,
-    })),
-  );
-}
-
-function releaseItemKey(item: ReleaseItem): string {
-  return item.pr
-    ? `pr-${item.pr}`
-    : `title-${item.title}-${item.rawTitle ?? ''}`;
-}
-
-function formatReleaseItemBullet(item: ReleaseItem): string {
+function formatReleaseItemBullet(item: ReleaseChange): string {
   let line = `- ${item.title}`;
   if (item.author) line += ` by @${item.author}`;
   if (item.pr && item.url) line += ` in [#${item.pr}](${item.url})`;
   return line;
 }
 
-function collectCategorizedReleaseItems(
-  section: string,
-  categories: Record<string, string[]>,
-  itemLookup: TitleLookup<ReleaseItem>,
-  seenItemKeys: Set<string>,
-): ReleaseItem[] {
-  const entries: ReleaseItem[] = [];
-  for (const candidateTitle of categories[section] || []) {
-    const item = findTitleMatch(candidateTitle, itemLookup, {
-      minRelativePrefixLength: RELEASE_TITLE_MATCH_MIN_RELATIVE_PREFIX_LENGTH,
-    });
-    if (!item) continue;
-
-    const itemKey = releaseItemKey(item);
-    if (seenItemKeys.has(itemKey)) continue;
-    entries.push(item);
-    seenItemKeys.add(itemKey);
-  }
-  return entries;
-}
-
 function appendCategorizedReleaseSections(
   lines: string[],
-  items: ReleaseItem[],
-  categories: Record<string, string[]>,
+  changes: ReleaseChange[],
+  assignments: CategoryAssignments,
 ): void {
-  const itemLookup = buildReleaseItemLookup(items);
-  const seenItemKeys = new Set<string>();
-
   for (const section of SECTION_ORDER) {
-    const entries = collectCategorizedReleaseItems(
-      section,
-      categories,
-      itemLookup,
-      seenItemKeys,
+    const entries = changes.filter(
+      (change) => assignments[change.id] === section,
     );
     if (!entries.length) continue;
 
@@ -101,21 +46,21 @@ function appendAdditionalReleaseSections(
 
 /**
  * Build a categorized changelog section from parsed release data.
- * @param params Version, date, items, category mapping, and optional additions.
+ * @param params Version, date, changes, category assignments, and optional additions.
  * @returns Markdown section string.
  */
 export function buildSectionFromRelease(params: {
   version: string;
   date: string;
-  items: ReleaseItem[];
-  categories: Record<string, string[]>;
+  changes: ReleaseChange[];
+  assignments: CategoryAssignments;
   fullChangelog?: string;
   sections?: ReleaseSection[];
 }): string {
-  const { version, date, items, categories, sections = [] } = params;
+  const { version, date, changes, assignments, sections = [] } = params;
   const lines: string[] = [`## [v${version}] - ${date}`, ''];
 
-  appendCategorizedReleaseSections(lines, items, categories);
+  appendCategorizedReleaseSections(lines, changes, assignments);
   appendAdditionalReleaseSections(lines, sections);
 
   if (params.fullChangelog) {

--- a/src/utils/release.ts
+++ b/src/utils/release.ts
@@ -3,6 +3,7 @@
 export { buildReleaseItemsFromPullRequests } from '@/utils/release-items.js';
 export {
   buildReleaseChangeId,
+  deduplicateReleaseChangesByPullRequest,
   identifyReleaseItems,
 } from '@/utils/release-items.js';
 export { parseReleaseNotes } from '@/utils/release-notes.js';

--- a/tests/lib/changelog-run-output.test.ts
+++ b/tests/lib/changelog-run-output.test.ts
@@ -35,7 +35,7 @@ const provider: Provider = {
     maxOutputTokens: 1000,
   },
   generate: async () => initialLlm,
-  classifyTitles: async () => ({}),
+  classifyChanges: async () => ({ assignments: {}, diagnostics: [] }),
   extractWhyNotes: async () => ({ items: [] }),
 };
 

--- a/tests/lib/changelog-run.test.ts
+++ b/tests/lib/changelog-run.test.ts
@@ -60,7 +60,7 @@ const provider: Provider = {
     pr_title: 'docs(changelog): test',
     pr_body: 'body',
   }),
-  classifyTitles: async () => ({}),
+  classifyChanges: async () => ({ assignments: {}, diagnostics: [] }),
   extractWhyNotes: async () => ({ items: [] }),
 };
 

--- a/tests/lib/why-extraction.test.ts
+++ b/tests/lib/why-extraction.test.ts
@@ -41,7 +41,10 @@ function provider(): Provider {
       pr_title: 'docs(changelog): 1.2.3',
       pr_body: 'body',
     })),
-    classifyTitles: jest.fn<Provider['classifyTitles']>(async () => ({})),
+    classifyChanges: jest.fn<Provider['classifyChanges']>(async () => ({
+      assignments: {},
+      diagnostics: [],
+    })),
     extractWhyNotes: jest.fn<Provider['extractWhyNotes']>(async () => ({
       items: [
         {

--- a/tests/providers/anthropic.test.ts
+++ b/tests/providers/anthropic.test.ts
@@ -9,15 +9,15 @@ describe('AnthropicProvider', () => {
     global.fetch = originalFetch;
   });
 
-  test('classifies titles from structured tool output', async () => {
+  test('classifies changes by ID from structured tool output', async () => {
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
           content: [
             {
               type: 'tool_use',
-              name: 'return_categories',
-              input: { Added: ['Add Anthropic support'] },
+              name: 'return_assignments',
+              input: { 'release-note:0': 'Added' },
             },
           ],
         }),
@@ -29,11 +29,15 @@ describe('AnthropicProvider', () => {
       model: 'claude-test-model',
     });
 
-    const output = await provider.classifyTitles(['Add Anthropic support'], {
-      throwOnError: true,
-    });
+    const output = await provider.classifyChanges(
+      [{ id: 'release-note:0', title: 'Add Anthropic support' }],
+      { throwOnError: true },
+    );
 
-    expect(output).toEqual({ Added: ['Add Anthropic support'] });
+    expect(output).toEqual({
+      assignments: { 'release-note:0': 'Added' },
+      diagnostics: [],
+    });
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.anthropic.com/v1/messages',
       expect.objectContaining({
@@ -50,7 +54,16 @@ describe('AnthropicProvider', () => {
       expect.objectContaining({
         model: 'claude-test-model',
         max_tokens: 1000,
-        tool_choice: { type: 'tool', name: 'return_categories' },
+        tool_choice: { type: 'tool', name: 'return_assignments' },
+      }),
+    );
+    expect(requestBody.tools[0].input_schema).toEqual(
+      expect.objectContaining({
+        required: ['release-note:0'],
+        additionalProperties: false,
+        properties: {
+          'release-note:0': expect.objectContaining({ type: 'string' }),
+        },
       }),
     );
   });

--- a/tests/providers/classification.test.ts
+++ b/tests/providers/classification.test.ts
@@ -1,50 +1,61 @@
 import { describe, expect, jest, test } from '@jest/globals';
 
-import { classifyTitlesWithFallback } from '@/providers/classification.js';
+import {
+  classifyChangesWithFallback,
+  parseCategoryAssignments,
+} from '@/providers/classification.js';
 
-describe('classifyTitlesWithFallback', () => {
+const changes = [{ id: 'release-note:0' as const, title: 'Fix lookup' }];
+
+describe('classifyChangesWithFallback', () => {
   test('returns an empty map without requesting classification for empty input', async () => {
     const request = jest.fn<() => Promise<string>>();
 
-    const result = await classifyTitlesWithFallback({
-      titles: [],
+    const result = await classifyChangesWithFallback({
+      changes: [],
       hasApiKey: true,
       request,
       invalidResponseMessage: 'Invalid response',
     });
 
-    expect(result).toEqual({});
+    expect(result).toEqual({ assignments: {}, diagnostics: [] });
     expect(request).not.toHaveBeenCalled();
   });
 
   test('uses the deterministic fallback without a provider key', async () => {
     const request = jest.fn<() => Promise<string>>();
 
-    const result = await classifyTitlesWithFallback({
-      titles: ['Update dependencies'],
+    const result = await classifyChangesWithFallback({
+      changes,
       hasApiKey: false,
       request,
       invalidResponseMessage: 'Invalid response',
     });
 
-    expect(result).toEqual({ Chore: ['Update dependencies'] });
+    expect(result).toEqual({
+      assignments: { 'release-note:0': 'Chore' },
+      diagnostics: [],
+    });
     expect(request).not.toHaveBeenCalled();
   });
 
   test('parses a valid provider response', async () => {
-    const result = await classifyTitlesWithFallback({
-      titles: ['Fix release lookup'],
+    const result = await classifyChangesWithFallback({
+      changes,
       hasApiKey: true,
-      request: async () => JSON.stringify({ Fixed: ['Fix release lookup'] }),
+      request: async () => JSON.stringify({ 'release-note:0': 'Fixed' }),
       invalidResponseMessage: 'Invalid response',
     });
 
-    expect(result).toEqual({ Fixed: ['Fix release lookup'] });
+    expect(result).toEqual({
+      assignments: { 'release-note:0': 'Fixed' },
+      diagnostics: [],
+    });
   });
 
   test('falls back when the provider request fails', async () => {
-    const result = await classifyTitlesWithFallback({
-      titles: ['Update dependencies'],
+    const result = await classifyChangesWithFallback({
+      changes,
       hasApiKey: true,
       request: async () => {
         throw new Error('Provider unavailable');
@@ -52,18 +63,67 @@ describe('classifyTitlesWithFallback', () => {
       invalidResponseMessage: 'Invalid response',
     });
 
-    expect(result).toEqual({ Chore: ['Update dependencies'] });
+    expect(result).toEqual({
+      assignments: { 'release-note:0': 'Chore' },
+      diagnostics: [
+        'Invalid response; used deterministic fallback for all changes',
+      ],
+    });
   });
 
   test('propagates invalid provider responses when requested', async () => {
     await expect(
-      classifyTitlesWithFallback({
-        titles: ['Fix release lookup'],
+      classifyChangesWithFallback({
+        changes,
         hasApiKey: true,
         options: { throwOnError: true },
-        request: async () => '{}',
+        request: async () => JSON.stringify({ 'release-note:0': ['Fixed'] }),
         invalidResponseMessage: 'Invalid provider response',
       }),
     ).rejects.toThrow('Invalid provider response');
+  });
+
+  test('fills missing IDs and records a reconciliation diagnostic', () => {
+    const result = parseCategoryAssignments(
+      JSON.stringify({ 'release-note:0': 'Fixed' }),
+      [...changes, { id: 'release-note:1', title: 'Add diagnostics' }],
+    );
+
+    expect(result).toEqual({
+      assignments: {
+        'release-note:0': 'Fixed',
+        'release-note:1': 'Chore',
+      },
+      diagnostics: [
+        'Classification response omitted 1 change ID(s): release-note:1; used deterministic fallback',
+      ],
+    });
+  });
+
+  test('rejects duplicate input IDs before reconciliation', () => {
+    expect(
+      parseCategoryAssignments(JSON.stringify({ 'release-note:0': 'Fixed' }), [
+        ...changes,
+        { id: 'release-note:0', title: 'Duplicate identity' },
+      ]),
+    ).toBeUndefined();
+  });
+
+  test.each([
+    {
+      caseName: 'an unknown category',
+      assignments: { 'release-note:0': 'Unknown' },
+    },
+    {
+      caseName: 'an unknown ID',
+      assignments: {
+        'release-note:0': 'Fixed',
+        'release-note:99': 'Added',
+      },
+    },
+  ])('rejects assignments containing $caseName', ({ assignments }) => {
+    expect(
+      parseCategoryAssignments(JSON.stringify(assignments), changes),
+    ).toBeUndefined();
   });
 });

--- a/tests/providers/classification.test.ts
+++ b/tests/providers/classification.test.ts
@@ -100,6 +100,23 @@ describe('classifyChangesWithFallback', () => {
     });
   });
 
+  test('rejects omitted assignments when strict mode is enabled', async () => {
+    await expect(
+      classifyChangesWithFallback({
+        changes: [
+          ...changes,
+          { id: 'release-note:1', title: 'Add diagnostics' },
+        ],
+        hasApiKey: true,
+        options: { throwOnError: true },
+        request: async () => JSON.stringify({ 'release-note:0': 'Fixed' }),
+        invalidResponseMessage: 'Invalid provider response',
+      }),
+    ).rejects.toThrow(
+      'Invalid provider response: Classification response omitted 1 change ID(s): release-note:1',
+    );
+  });
+
   test('rejects duplicate input IDs before reconciliation', () => {
     expect(
       parseCategoryAssignments(JSON.stringify({ 'release-note:0': 'Fixed' }), [

--- a/tests/providers/gemini.test.ts
+++ b/tests/providers/gemini.test.ts
@@ -73,7 +73,7 @@ describe('GeminiProvider', () => {
     expect(requestBody.generationConfig.responseFormat).toBeUndefined();
   });
 
-  test('classifies titles via generateContent', async () => {
+  test('classifies changes by ID via generateContent', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       text: async () =>
@@ -83,9 +83,7 @@ describe('GeminiProvider', () => {
               content: {
                 parts: [
                   {
-                    text: JSON.stringify({
-                      Added: ['Add Gemini support'],
-                    }),
+                    text: JSON.stringify({ 'release-note:0': 'Added' }),
                   },
                 ],
               },
@@ -99,9 +97,14 @@ describe('GeminiProvider', () => {
       model: 'gemini-test-model',
     });
 
-    const output = await provider.classifyTitles(['Add Gemini support']);
+    const output = await provider.classifyChanges([
+      { id: 'release-note:0', title: 'Add Gemini support' },
+    ]);
 
-    expect(output).toEqual({ Added: ['Add Gemini support'] });
+    expect(output).toEqual({
+      assignments: { 'release-note:0': 'Added' },
+      diagnostics: [],
+    });
     expect(global.fetch).toHaveBeenCalledWith(
       'https://generativelanguage.googleapis.com/v1beta/models/gemini-test-model:generateContent',
       expect.objectContaining({
@@ -118,6 +121,10 @@ describe('GeminiProvider', () => {
         responseMimeType: 'application/json',
         responseJsonSchema: expect.objectContaining({
           type: 'object',
+          required: ['release-note:0'],
+          properties: {
+            'release-note:0': expect.objectContaining({ type: 'string' }),
+          },
           additionalProperties: false,
         }),
       }),
@@ -133,7 +140,9 @@ describe('GeminiProvider', () => {
           candidates: [
             {
               content: {
-                parts: [{ text: JSON.stringify({ Added: 'not-array' }) }],
+                parts: [
+                  { text: JSON.stringify({ 'release-note:0': ['Added'] }) },
+                ],
               },
             },
           ],
@@ -146,7 +155,10 @@ describe('GeminiProvider', () => {
     });
 
     await expect(
-      provider.classifyTitles(['Add Gemini support'], { throwOnError: true }),
+      provider.classifyChanges(
+        [{ id: 'release-note:0', title: 'Add Gemini support' }],
+        { throwOnError: true },
+      ),
     ).rejects.toThrow('Gemini classify output did not match schema');
   });
 
@@ -158,7 +170,9 @@ describe('GeminiProvider', () => {
           candidates: [
             {
               content: {
-                parts: [{ text: JSON.stringify({ Added: 'not-array' }) }],
+                parts: [
+                  { text: JSON.stringify({ 'release-note:0': ['Added'] }) },
+                ],
               },
             },
           ],
@@ -171,9 +185,14 @@ describe('GeminiProvider', () => {
     });
 
     await expect(
-      provider.classifyTitles(['Add Gemini support']),
+      provider.classifyChanges([
+        { id: 'release-note:0', title: 'Add Gemini support' },
+      ]),
     ).resolves.toEqual({
-      Chore: ['Add Gemini support'],
+      assignments: { 'release-note:0': 'Chore' },
+      diagnostics: [
+        'Gemini classify output did not match schema; used deterministic fallback for all changes',
+      ],
     });
   });
 });

--- a/tests/providers/openai.test.ts
+++ b/tests/providers/openai.test.ts
@@ -112,11 +112,11 @@ describe('OpenAIProvider', () => {
     expect(requestBody).not.toHaveProperty('reasoning');
   });
 
-  test('classifies titles from reasoning models via the Responses API', async () => {
+  test('classifies changes by ID from reasoning models via the Responses API', async () => {
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
-          output_text: JSON.stringify({ Fixed: ['Fix release lookup'] }),
+          output_text: JSON.stringify({ 'release-note:0': 'Fixed' }),
         }),
       ),
     );
@@ -126,11 +126,15 @@ describe('OpenAIProvider', () => {
       model: 'gpt-5.1-reasoning',
     });
 
-    const output = await provider.classifyTitles(['Fix release lookup'], {
-      throwOnError: true,
-    });
+    const output = await provider.classifyChanges(
+      [{ id: 'release-note:0', title: 'Fix release lookup' }],
+      { throwOnError: true },
+    );
 
-    expect(output).toEqual({ Fixed: ['Fix release lookup'] });
+    expect(output).toEqual({
+      assignments: { 'release-note:0': 'Fixed' },
+      diagnostics: [],
+    });
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.openai.com/v1/responses',
       expect.objectContaining({ method: 'POST' }),

--- a/tests/utils/category-tune-score.test.ts
+++ b/tests/utils/category-tune-score.test.ts
@@ -1,30 +1,33 @@
 // @ts-nocheck
 import { describe, test, expect } from '@jest/globals';
-import { tuneCategoriesByTitle } from '@/utils/category-tune.js';
+import { tuneCategoryAssignmentsByTitle } from '@/utils/category-tune.js';
 
 describe('category-tune with scoring thresholds', () => {
   test('moves improvement-heavy titles from Chore to Changed', () => {
     const items = [
       {
+        id: 'release-note:0',
+        origin: { kind: 'release-note', index: 0 },
         title: 'add pre-processing to improve classification',
         rawTitle: undefined,
       },
     ];
-    const categories = {
-      Chore: ['add pre-processing to improve classification'],
-    };
-    const out = tuneCategoriesByTitle(items, categories);
-    expect(out.Changed).toContain(
-      'add pre-processing to improve classification',
-    );
+    const assignments = { 'release-note:0': 'Chore' as const };
+    const out = tuneCategoryAssignmentsByTitle(items, assignments);
+    expect(out['release-note:0']).toBe('Changed');
   });
 
   test('does not demote explicit Fixed', () => {
     const items = [
-      { title: 'fix: prevent crash', rawTitle: 'fix: prevent crash' },
+      {
+        id: 'release-note:0',
+        origin: { kind: 'release-note' as const, index: 0 },
+        title: 'fix: prevent crash',
+        rawTitle: 'fix: prevent crash',
+      },
     ];
-    const categories = { Fixed: ['fix: prevent crash'] };
-    const out = tuneCategoriesByTitle(items, categories);
-    expect(out.Fixed).toContain('fix: prevent crash');
+    const assignments = { 'release-note:0': 'Fixed' as const };
+    const out = tuneCategoryAssignmentsByTitle(items, assignments);
+    expect(out['release-note:0']).toBe('Fixed');
   });
 });

--- a/tests/utils/category-tune.test.ts
+++ b/tests/utils/category-tune.test.ts
@@ -1,77 +1,86 @@
 // eslint-disable @typescript-eslint/no-explicit-any -- Tests may coerce types when focusing on behavior, not type surfaces.
-import { tuneCategoriesByTitle } from '@/utils/category-tune.js';
-import type { ReleaseItem } from '@/types/release.js';
-import type { CategoryMap } from '@/types/changelog.js';
+import { tuneCategoryAssignmentsByTitle } from '@/utils/category-tune.js';
+import type { ReleaseChange } from '@/types/release.js';
+import type { CategoryAssignments } from '@/types/changelog.js';
 
-describe('tuneCategoriesByTitle', () => {
+describe('tuneCategoryAssignmentsByTitle', () => {
   test('moves conventional fix-like titles to Fixed', () => {
-    const items: ReleaseItem[] = [
-      { title: 'tighten option type', rawTitle: 'chore: tighten option type' },
+    const items: ReleaseChange[] = [
+      {
+        id: 'release-note:0',
+        origin: { kind: 'release-note', index: 0 },
+        title: 'tighten option type',
+        rawTitle: 'chore: tighten option type',
+      },
     ];
-    const categories: CategoryMap = { Chore: ['chore: tighten option type'] };
-    const out = tuneCategoriesByTitle(items, categories);
-    expect(out.Fixed).toContain('chore: tighten option type');
+    const assignments: CategoryAssignments = { 'release-note:0': 'Chore' };
+    const out = tuneCategoryAssignmentsByTitle(items, assignments);
+    expect(out['release-note:0']).toBe('Fixed');
   });
 
   test('moves refactor-like titles to Changed', () => {
-    const items: ReleaseItem[] = [
+    const items: ReleaseChange[] = [
       {
+        id: 'release-note:0',
+        origin: { kind: 'release-note', index: 0 },
         title: 'refactor: internal pipeline',
         rawTitle: 'refactor: internal pipeline',
       },
     ];
-    const categories: CategoryMap = { Chore: ['refactor: internal pipeline'] };
-    const out = tuneCategoriesByTitle(items, categories);
-    expect(out.Changed).toContain('refactor: internal pipeline');
+    const assignments: CategoryAssignments = { 'release-note:0': 'Chore' };
+    const out = tuneCategoryAssignmentsByTitle(items, assignments);
+    expect(out['release-note:0']).toBe('Changed');
   });
 
   test('moves feat: titles to Added', () => {
-    const items: ReleaseItem[] = [
+    const items: ReleaseChange[] = [
       {
+        id: 'release-note:0',
+        origin: { kind: 'release-note', index: 0 },
         title: 'Support GitHub App auth',
         rawTitle: 'feat: Support GitHub App auth',
       },
     ];
-    const categories: CategoryMap = {
-      Chore: ['feat: Support GitHub App auth'],
-    };
-    const out = tuneCategoriesByTitle(items, categories);
-    expect(out.Added).toContain('feat: Support GitHub App auth');
-    // Ensure it is removed from Chore
-    expect(out.Chore?.includes('feat: Support GitHub App auth')).toBeFalsy();
+    const assignments: CategoryAssignments = { 'release-note:0': 'Chore' };
+    const out = tuneCategoryAssignmentsByTitle(items, assignments);
+    expect(out['release-note:0']).toBe('Added');
   });
 
   test('matches feat(scope)!: and fix(scope)!: forms', () => {
-    const items: ReleaseItem[] = [
-      { title: 'Breaking feature', rawTitle: 'feat(core)!: new something' },
-      { title: 'Critical fix', rawTitle: 'fix(api)!: patch issue' },
+    const items: ReleaseChange[] = [
+      {
+        id: 'release-note:0',
+        origin: { kind: 'release-note', index: 0 },
+        title: 'Breaking feature',
+        rawTitle: 'feat(core)!: new something',
+      },
+      {
+        id: 'release-note:1',
+        origin: { kind: 'release-note', index: 1 },
+        title: 'Critical fix',
+        rawTitle: 'fix(api)!: patch issue',
+      },
     ];
-    const categories: CategoryMap = {
-      Chore: ['feat(core)!: new something', 'fix(api)!: patch issue'],
+    const assignments: CategoryAssignments = {
+      'release-note:0': 'Chore',
+      'release-note:1': 'Chore',
     };
-    const out = tuneCategoriesByTitle(items, categories);
-    expect(out.Added).toContain('feat(core)!: new something');
-    expect(out.Fixed).toContain('fix(api)!: patch issue');
+    const out = tuneCategoryAssignmentsByTitle(items, assignments);
+    expect(out['release-note:0']).toBe('Added');
+    expect(out['release-note:1']).toBe('Fixed');
   });
 
   test('keeps dependency-only updates in Chore', () => {
-    const items: ReleaseItem[] = [
+    const items: ReleaseChange[] = [
       {
+        id: 'release-note:0',
+        origin: { kind: 'release-note', index: 0 },
         title: 'Update dependency prettier to v3.8.0',
         rawTitle: 'chore(deps): Update dependency prettier to v3.8.0',
       },
     ];
-    const categories: CategoryMap = {
-      Changed: ['chore(deps): Update dependency prettier to v3.8.0'],
-    };
-    const out = tuneCategoriesByTitle(items, categories);
-    expect(out.Chore).toContain(
-      'chore(deps): Update dependency prettier to v3.8.0',
-    );
-    expect(
-      out.Changed?.includes(
-        'chore(deps): Update dependency prettier to v3.8.0',
-      ),
-    ).toBeFalsy();
+    const assignments: CategoryAssignments = { 'release-note:0': 'Changed' };
+    const out = tuneCategoryAssignmentsByTitle(items, assignments);
+    expect(out['release-note:0']).toBe('Chore');
   });
 });

--- a/tests/utils/classify-pre-score.test.ts
+++ b/tests/utils/classify-pre-score.test.ts
@@ -1,30 +1,39 @@
 // @ts-nocheck
 import { describe, test, expect } from '@jest/globals';
-import { buildTitlesForClassification } from '@/utils/classify-pre.js';
+import { buildChangesForClassification } from '@/utils/classify-pre.js';
+
+function releaseNoteChange(index, title, rawTitle) {
+  return {
+    id: `release-note:${index}`,
+    origin: { kind: 'release-note', index },
+    title,
+    rawTitle,
+  };
+}
 
 describe('classify-pre with scoring', () => {
   test('guides to refactor for improvement titles', () => {
     const items = [
-      {
-        title: 'add pre-processing to improve classification',
-        rawTitle: undefined,
-      },
+      releaseNoteChange(0, 'add pre-processing to improve classification'),
     ];
-    const out = buildTitlesForClassification(items);
-    expect(out[0]).toMatch(/^refactor:/);
+    const out = buildChangesForClassification(items);
+    expect(out[0].title).toMatch(/^refactor:/);
+    expect(out[0].id).toBe('release-note:0');
   });
 
   test('guides to fix for tighten type', () => {
     const items = [
-      { title: 'tighten option type to prevent misuse', rawTitle: undefined },
+      releaseNoteChange(0, 'tighten option type to prevent misuse'),
     ];
-    const out = buildTitlesForClassification(items);
-    expect(out[0]).toMatch(/^fix:/);
+    const out = buildChangesForClassification(items);
+    expect(out[0].title).toMatch(/^fix:/);
   });
 
   test('keeps explicit feat', () => {
-    const items = [{ title: 'feat: add option', rawTitle: 'feat: add option' }];
-    const out = buildTitlesForClassification(items);
-    expect(out[0]).toBe('feat: add option');
+    const items = [
+      releaseNoteChange(0, 'feat: add option', 'feat: add option'),
+    ];
+    const out = buildChangesForClassification(items);
+    expect(out[0].title).toBe('feat: add option');
   });
 });

--- a/tests/utils/classify.test.ts
+++ b/tests/utils/classify.test.ts
@@ -8,14 +8,14 @@ import {
   jest,
 } from '@jest/globals';
 import { loadAppConfig } from '@/lib/app-config.js';
-import { classifyTitles } from '@/utils/classify.js';
+import { classifyChanges } from '@/utils/classify.js';
 import {
   PROVIDER_OPENAI,
   PROVIDER_ANTHROPIC,
   PROVIDER_GEMINI,
 } from '@/constants/provider.js';
 
-describe('classifyTitles', () => {
+describe('classifyChanges', () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
@@ -28,15 +28,22 @@ describe('classifyTitles', () => {
 
   test('falls back to Chore when no API key', async () => {
     const config = loadAppConfig({}).providers.openai;
-    const out = await classifyTitles(['Add login'], PROVIDER_OPENAI, config);
+    const out = await classifyChanges(
+      [{ id: 'release-note:0', title: 'Add login' }],
+      PROVIDER_OPENAI,
+      config,
+    );
 
-    expect(out).toEqual({ Chore: ['Add login'] });
+    expect(out.assignments).toEqual({ 'release-note:0': 'Chore' });
   });
 
   test('falls back to Chore when provider config is omitted', async () => {
-    const out = await classifyTitles(['Add login'], PROVIDER_OPENAI);
+    const out = await classifyChanges(
+      [{ id: 'release-note:0', title: 'Add login' }],
+      PROVIDER_OPENAI,
+    );
 
-    expect(out).toEqual({ Chore: ['Add login'] });
+    expect(out.assignments).toEqual({ 'release-note:0': 'Chore' });
   });
 
   test('classifies via OpenAI with mocked fetch', async () => {
@@ -47,7 +54,7 @@ describe('classifyTitles', () => {
           choices: [
             {
               message: {
-                content: JSON.stringify({ Added: ['Add login'] }),
+                content: JSON.stringify({ 'release-note:0': 'Added' }),
               },
             },
           ],
@@ -56,9 +63,13 @@ describe('classifyTitles', () => {
 
     const config = loadAppConfig({ OPENAI_API_KEY: 'sk-test' }).providers
       .openai;
-    const out = await classifyTitles(['Add login'], PROVIDER_OPENAI, config);
+    const out = await classifyChanges(
+      [{ id: 'release-note:0', title: 'Add login' }],
+      PROVIDER_OPENAI,
+      config,
+    );
 
-    expect(out).toEqual({ Added: ['Add login'] });
+    expect(out.assignments).toEqual({ 'release-note:0': 'Added' });
   });
 
   test('classifies via Anthropic with mocked fetch', async () => {
@@ -66,16 +77,20 @@ describe('classifyTitles', () => {
       ok: true,
       text: async () =>
         JSON.stringify({
-          content: [{ text: JSON.stringify({ Fixed: ['Fix bug'] }) }],
+          content: [{ text: JSON.stringify({ 'release-note:0': 'Fixed' }) }],
         }),
     });
 
     const config = loadAppConfig({
       ANTHROPIC_API_KEY: 'ak-test',
     }).providers.anthropic;
-    const out = await classifyTitles(['Fix bug'], PROVIDER_ANTHROPIC, config);
+    const out = await classifyChanges(
+      [{ id: 'release-note:0', title: 'Fix bug' }],
+      PROVIDER_ANTHROPIC,
+      config,
+    );
 
-    expect(out).toEqual({ Fixed: ['Fix bug'] });
+    expect(out.assignments).toEqual({ 'release-note:0': 'Fixed' });
   });
 
   test('classifies via Gemini with mocked fetch', async () => {
@@ -86,7 +101,9 @@ describe('classifyTitles', () => {
           candidates: [
             {
               content: {
-                parts: [{ text: JSON.stringify({ Changed: ['Tune parser'] }) }],
+                parts: [
+                  { text: JSON.stringify({ 'release-note:0': 'Changed' }) },
+                ],
               },
             },
           ],
@@ -96,8 +113,12 @@ describe('classifyTitles', () => {
     const config = loadAppConfig({
       GEMINI_API_KEY: 'gemini-test',
     }).providers.gemini;
-    const out = await classifyTitles(['Tune parser'], PROVIDER_GEMINI, config);
+    const out = await classifyChanges(
+      [{ id: 'release-note:0', title: 'Tune parser' }],
+      PROVIDER_GEMINI,
+      config,
+    );
 
-    expect(out).toEqual({ Changed: ['Tune parser'] });
+    expect(out.assignments).toEqual({ 'release-note:0': 'Changed' });
   });
 });

--- a/tests/utils/llm-output.test.ts
+++ b/tests/utils/llm-output.test.ts
@@ -11,6 +11,8 @@ await jest.unstable_mockModule('@/utils/classify.js', () => ({
 
 const { buildChangelogLlmOutput } = await import('@/utils/llm-output.js');
 const { LlmError } = await import('@/lib/errors.js');
+const { classifyChangesWithFallback } =
+  await import('@/providers/classification.js');
 
 const mockProvider = {
   name: 'openai',
@@ -201,15 +203,15 @@ describe('llm-output', () => {
   });
 
   test('records omitted classification IDs and renders their fallback', async () => {
-    const classifyChanges = jest.fn(async () => ({
-      assignments: {
-        'release-note:0': 'Added',
-        'release-note:1': 'Chore',
-      },
-      diagnostics: [
-        'Classification response omitted 1 change ID(s): release-note:1; used deterministic fallback',
-      ],
-    }));
+    const classifyChanges = jest.fn((changes, options) =>
+      classifyChangesWithFallback({
+        changes,
+        hasApiKey: true,
+        options,
+        request: async () => JSON.stringify({ 'release-note:0': 'Added' }),
+        invalidResponseMessage: 'Invalid provider response',
+      }),
+    );
 
     const result = await buildChangelogLlmOutput(
       buildBaseParams({
@@ -428,6 +430,33 @@ describe('llm-output', () => {
       buildChangelogLlmOutput(
         buildBaseParams({
           releaseBody: "## What's Changed\n- Add feature\n",
+          provider: { ...mockProvider, classifyChanges },
+          hasProviderKey: true,
+          failOnLlmError: true,
+        }),
+      ),
+    ).rejects.toThrow(LlmError);
+  });
+
+  test('fail-on-llm-error throws when classification omits a change ID', async () => {
+    const classifyChanges = jest.fn((changes, options) =>
+      classifyChangesWithFallback({
+        changes,
+        hasApiKey: true,
+        options,
+        request: async () => JSON.stringify({ 'release-note:0': 'Added' }),
+        invalidResponseMessage: 'Invalid provider response',
+      }),
+    );
+
+    await expect(
+      buildChangelogLlmOutput(
+        buildBaseParams({
+          releaseBody: [
+            "## What's Changed",
+            '- Add feature',
+            '- Routine maintenance',
+          ].join('\n'),
           provider: { ...mockProvider, classifyChanges },
           hasProviderKey: true,
           failOnLlmError: true,

--- a/tests/utils/llm-output.test.ts
+++ b/tests/utils/llm-output.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, test, jest } from '@jest/globals';
 
 // With ESM + ts-jest, mock modules before importing the SUT using unstable_mockModule.
 await jest.unstable_mockModule('@/utils/classify.js', () => ({
-  classifyTitles: jest.fn(async () => ({ Added: ['Add feature'] })),
+  classifyChanges: jest.fn(async () => ({
+    assignments: { 'release-note:0': 'Added' },
+    diagnostics: [],
+  })),
 }));
 
 const { buildChangelogLlmOutput } = await import('@/utils/llm-output.js');
@@ -21,7 +24,10 @@ const mockProvider = {
   generate: async () => {
     throw new Error('Unexpected model call');
   },
-  classifyTitles: async () => ({ Added: ['Add feature'] }),
+  classifyChanges: async (changes) => ({
+    assignments: Object.fromEntries(changes.map(({ id }) => [id, 'Added'])),
+    diagnostics: [],
+  }),
 };
 
 const mockProviderConfig = {
@@ -94,21 +100,89 @@ describe('llm-output', () => {
     expect(result.llm.new_section_markdown).toContain('- Add feature');
   });
 
+  test('classifies duplicate titles independently by stable ID', async () => {
+    const classifyChanges = jest.fn(async () => ({
+      assignments: {
+        'release-note:0': 'Added',
+        'release-note:1': 'Fixed',
+      },
+      diagnostics: [],
+    }));
+
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: [
+          "## What's Changed",
+          '- Surface status',
+          '- Surface status',
+        ].join('\n'),
+        provider: { ...mockProvider, classifyChanges },
+        hasProviderKey: true,
+      }),
+    );
+
+    expect(classifyChanges).toHaveBeenCalledWith(
+      [
+        { id: 'release-note:0', title: 'Surface status' },
+        { id: 'release-note:1', title: 'Surface status' },
+      ],
+      { throwOnError: true },
+    );
+    expect(result.llm.new_section_markdown).toContain(
+      '### Added\n\n- Surface status',
+    );
+    expect(result.llm.new_section_markdown).toContain(
+      '### Fixed\n\n- Surface status',
+    );
+    expect(
+      result.llm.new_section_markdown.match(/- Surface status/g),
+    ).toHaveLength(2);
+  });
+
+  test('records omitted classification IDs and renders their fallback', async () => {
+    const classifyChanges = jest.fn(async () => ({
+      assignments: {
+        'release-note:0': 'Added',
+        'release-note:1': 'Chore',
+      },
+      diagnostics: [
+        'Classification response omitted 1 change ID(s): release-note:1; used deterministic fallback',
+      ],
+    }));
+
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: [
+          "## What's Changed",
+          '- Add export',
+          '- Routine maintenance',
+        ].join('\n'),
+        provider: { ...mockProvider, classifyChanges },
+        hasProviderKey: true,
+      }),
+    );
+
+    expect(result.fallbackReasons).toContain(
+      'Classification response omitted 1 change ID(s): release-note:1; used deterministic fallback',
+    );
+    expect(result.llm.new_section_markdown).toContain('- Routine maintenance');
+  });
+
   test('no-ai uses release notes without provider classification', async () => {
-    const classifyTitles = jest.fn(async () => {
+    const classifyChanges = jest.fn(async () => {
       throw new Error('classification should be skipped');
     });
 
     const result = await buildChangelogLlmOutput(
       buildBaseParams({
         releaseBody: "## What's Changed\n- Add feature\n",
-        provider: { ...mockProvider, classifyTitles },
+        provider: { ...mockProvider, classifyChanges },
         hasProviderKey: true,
         noAi: true,
       }),
     );
 
-    expect(classifyTitles).not.toHaveBeenCalled();
+    expect(classifyChanges).not.toHaveBeenCalled();
     expect(result.aiUsed).toBe(false);
     expect(result.fallbackReasons).toEqual(
       expect.arrayContaining([
@@ -285,7 +359,7 @@ describe('llm-output', () => {
   });
 
   test('fail-on-llm-error throws when mocked release-note classification fails', async () => {
-    const classifyTitles = jest.fn(async () => {
+    const classifyChanges = jest.fn(async () => {
       throw new Error('classifier down');
     });
 
@@ -293,7 +367,7 @@ describe('llm-output', () => {
       buildChangelogLlmOutput(
         buildBaseParams({
           releaseBody: "## What's Changed\n- Add feature\n",
-          provider: { ...mockProvider, classifyTitles },
+          provider: { ...mockProvider, classifyChanges },
           hasProviderKey: true,
           failOnLlmError: true,
         }),

--- a/tests/utils/llm-output.test.ts
+++ b/tests/utils/llm-output.test.ts
@@ -139,6 +139,36 @@ describe('llm-output', () => {
     ).toHaveLength(2);
   });
 
+  test('classifies and renders a repeated explicit PR only once', async () => {
+    const classifyChanges = jest.fn(async () => ({
+      assignments: { 'pr:42': 'Added' },
+      diagnostics: [],
+    }));
+
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: [
+          "## What's Changed",
+          '- feat: Add export support by @alice in #42',
+          '- feat: Add export support by @alice in #42',
+        ].join('\n'),
+        provider: { ...mockProvider, classifyChanges },
+        hasProviderKey: true,
+      }),
+    );
+
+    expect(classifyChanges).toHaveBeenCalledWith(
+      [{ id: 'pr:42', title: 'feat: Add export support' }],
+      { throwOnError: true },
+    );
+    expect(
+      result.llm.new_section_markdown.match(/- Add export support/g),
+    ).toHaveLength(1);
+    expect(result.fallbackReasons.join('\n')).not.toContain(
+      'LLM classification failed',
+    );
+  });
+
   test('records omitted classification IDs and renders their fallback', async () => {
     const classifyChanges = jest.fn(async () => ({
       assignments: {

--- a/tests/utils/llm-output.test.ts
+++ b/tests/utils/llm-output.test.ts
@@ -169,6 +169,37 @@ describe('llm-output', () => {
     );
   });
 
+  test('deduplicates PRs resolved from titles before classification', async () => {
+    const classifyChanges = jest.fn(async () => ({
+      assignments: { 'release-note:0': 'Added' },
+      diagnostics: [],
+    }));
+
+    const result = await buildChangelogLlmOutput(
+      buildBaseParams({
+        releaseBody: [
+          "## What's Changed",
+          '- Add export support by @alice',
+          '- Add export support by @alice',
+        ].join('\n'),
+        titleToPr: { 'add export support': 42 },
+        provider: { ...mockProvider, classifyChanges },
+        hasProviderKey: true,
+      }),
+    );
+
+    expect(classifyChanges).toHaveBeenCalledWith(
+      [{ id: 'release-note:0', title: 'Add export support' }],
+      { throwOnError: true },
+    );
+    expect(
+      result.llm.new_section_markdown.match(/- Add export support/g),
+    ).toHaveLength(1);
+    expect(result.llm.new_section_markdown).toContain(
+      '[#42](https://github.com/octo/repo/pull/42)',
+    );
+  });
+
   test('records omitted classification IDs and renders their fallback', async () => {
     const classifyChanges = jest.fn(async () => ({
       assignments: {

--- a/tests/utils/release.test.ts
+++ b/tests/utils/release.test.ts
@@ -2,6 +2,7 @@
 import { test, expect, describe } from '@jest/globals';
 import {
   buildReleaseItemsFromPullRequests,
+  deduplicateReleaseChangesByPullRequest,
   identifyReleaseItems,
   parseReleaseNotes,
   buildSectionFromRelease,
@@ -115,6 +116,30 @@ describe('release utils', () => {
         origin: { kind: 'pull-request', number: 42 },
         title: 'Add export support',
         rawTitle: 'feat: Add export support',
+        author: 'alice',
+        pr: 42,
+        url: 'https://github.com/acme/repo/pull/42',
+      },
+    ]);
+  });
+
+  test('deduplicates PRs discovered after initial identification', () => {
+    const changes = identifyReleaseItems([
+      { title: 'Add export support' },
+      {
+        title: 'Explicit export entry',
+        author: 'alice',
+        pr: 42,
+        url: 'https://github.com/acme/repo/pull/42',
+      },
+    ]);
+    changes[0].pr = 42;
+
+    expect(deduplicateReleaseChangesByPullRequest(changes)).toEqual([
+      {
+        id: 'release-note:0',
+        origin: { kind: 'release-note', index: 0 },
+        title: 'Add export support',
         author: 'alice',
         pr: 42,
         url: 'https://github.com/acme/repo/pull/42',

--- a/tests/utils/release.test.ts
+++ b/tests/utils/release.test.ts
@@ -94,6 +94,34 @@ describe('release utils', () => {
     ]);
   });
 
+  test('deduplicates repeated explicit PRs before classification', () => {
+    const changes = identifyReleaseItems([
+      {
+        title: 'Add export support',
+        rawTitle: 'feat: Add export support',
+        pr: 42,
+      },
+      {
+        title: 'Mention export support again',
+        author: 'alice',
+        pr: 42,
+        url: 'https://github.com/acme/repo/pull/42',
+      },
+    ]);
+
+    expect(changes).toEqual([
+      {
+        id: 'pr:42',
+        origin: { kind: 'pull-request', number: 42 },
+        title: 'Add export support',
+        rawTitle: 'feat: Add export support',
+        author: 'alice',
+        pr: 42,
+        url: 'https://github.com/acme/repo/pull/42',
+      },
+    ]);
+  });
+
   test('parseReleaseNotes extracts items and full changelog', () => {
     const body = [
       '# Some Release',

--- a/tests/utils/release.test.ts
+++ b/tests/utils/release.test.ts
@@ -312,8 +312,10 @@ describe('release utils', () => {
   });
 
   test('buildSectionFromRelease formats bullets with author and PR link', () => {
-    const items = [
+    const changes = [
       {
+        id: 'pr:123',
+        origin: { kind: 'pull-request', number: 123 },
         title: 'Add thing',
         author: 'alice',
         pr: 123,
@@ -324,8 +326,8 @@ describe('release utils', () => {
     const section = buildSectionFromRelease({
       version: '0.1.1',
       date: '2024-01-01',
-      items,
-      categories: { Added: ['Add thing'] },
+      changes,
+      assignments: { 'pr:123': 'Added' },
       fullChangelog: 'https://github.com/acme/repo/compare/v0.1.0...v0.1.1',
       sections: [
         {
@@ -353,8 +355,8 @@ describe('release utils', () => {
     const section = buildSectionFromRelease({
       version: '1.8.0',
       date: '2026-06-06',
-      items: [],
-      categories: {},
+      changes: [],
+      assignments: {},
       sections: [
         {
           heading: 'What\u2019s new \u{1F680}',
@@ -380,22 +382,21 @@ describe('release utils', () => {
     expect(section).toContain('```ts\n### Not a markdown heading\n');
   });
 
-  test('buildSectionFromRelease matches raw conventional titles and avoids duplicate category membership', () => {
+  test('buildSectionFromRelease renders a change from its stable ID assignment', () => {
     const section = buildSectionFromRelease({
       version: '1.2.3',
       date: '2026-05-16',
-      items: [
+      changes: [
         {
+          id: 'pr:100',
+          origin: { kind: 'pull-request', number: 100 },
           title: 'Add export flag',
           rawTitle: 'feat: Add export flag',
           pr: 100,
           url: 'https://github.com/acme/repo/pull/100',
         },
       ],
-      categories: {
-        Added: ['feat: Add export flag'],
-        Changed: ['Add export flag'],
-      },
+      assignments: { 'pr:100': 'Added' },
     });
 
     expect(section).toBe(
@@ -408,5 +409,32 @@ describe('release utils', () => {
         '',
       ].join('\n'),
     );
+  });
+
+  test('buildSectionFromRelease keeps duplicate titles in separate assigned sections', () => {
+    const section = buildSectionFromRelease({
+      version: '1.2.3',
+      date: '2026-05-16',
+      changes: [
+        {
+          id: 'release-note:0',
+          origin: { kind: 'release-note', index: 0 },
+          title: 'Improve output',
+        },
+        {
+          id: 'release-note:1',
+          origin: { kind: 'release-note', index: 1 },
+          title: 'Improve output',
+        },
+      ],
+      assignments: {
+        'release-note:0': 'Added',
+        'release-note:1': 'Fixed',
+      },
+    });
+
+    expect(section).toContain('### Added\n\n- Improve output');
+    expect(section).toContain('### Fixed\n\n- Improve output');
+    expect(section.match(/- Improve output/g)).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

Classify release changes by stable ID.

<!-- A brief summary of the changes -->

## Description

- replace category-to-title classification with ID-to-category assignments
- update OpenAI, Anthropic, and Gemini providers to classify canonical release changes
- reject unknown change IDs and unsupported categories

<!-- A detailed explanation of the changes, including why they are needed -->
